### PR TITLE
Fix #9: corregido diagrama Mermaid en ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,10 +21,10 @@ Este documento describe la arquitectura técnica del sistema, los componentes, e
 
 ```mermaid
 flowchart LR
-    Client[Cliente (Browser)] -->|HTTP/HTTPS| NGINX[(NGINX \n Reverse Proxy)]
-    NGINX -->|/| FE[Frontend: React (estático)]
+    Client[Cliente Browser] -->|HTTP or HTTPS| NGINX[(NGINX <br/> Reverse Proxy)]
+    NGINX -->|/| FE[Frontend: React estatico]
     NGINX -->|/api| BE[Backend: Spring Boot]
-    BE -->|JPA/Hibernate| DB[(PostgreSQL)]
+    BE -->|JPA-Hibernate| DB[(PostgreSQL)]
 
     subgraph Docker Network
       FE --- BE


### PR DESCRIPTION
Se corrigió el error de renderizado en el diagrama Mermaid de ARCHITECTURE.md
- Reemplazado `\n` por `<br/>` en los labels.
- Quité ( y ) en los textos de los nodos
- Quité acentos (estatico en vez de estático)

Este PR soluciona el issue #9
Closes #9