### PR TITLE
Refactor: migrar autenticación y registro de usuario de username a email

### DIFF
--- a/src/main/java/com/coworking/config/SecurityConfig.java
+++ b/src/main/java/com/coworking/config/SecurityConfig.java
@@ -32,6 +32,12 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/coworking/config/SecurityConfig.java
+++ b/src/main/java/com/coworking/config/SecurityConfig.java
@@ -1,19 +1,22 @@
 package com.coworking.config;
 
 import com.coworking.security.JwtAuthenticationFilter;
-import org.hibernate.sql.ast.tree.from.CorrelatedTableGroup;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.List;
+
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig {
 
     @Bean
@@ -30,6 +33,15 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter) throws Exception{
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(request -> {
+                    var corsConfiguration = new org.springframework.web.cors.CorsConfiguration();
+                    corsConfiguration.setAllowedOrigins(List.of("http://localhost:5174"));
+                    corsConfiguration.setAllowedOrigins(List.of("http://localhost:5173"));
+                    corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+                    corsConfiguration.setAllowedHeaders(List.of("*"));
+                    corsConfiguration.setAllowCredentials(true);
+                    return corsConfiguration;
+                }))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers(
@@ -37,7 +49,9 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
                                 "/swagger-ui.html"
+
                         ).permitAll()
+                        .requestMatchers("/api/hello").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/coworking/controller/AuthController.java
+++ b/src/main/java/com/coworking/controller/AuthController.java
@@ -1,6 +1,4 @@
 package com.coworking.controller;
-
-
 import com.coworking.dto.AuthRequest;
 import com.coworking.dto.AuthResponse;
 import com.coworking.security.JwtUtil;
@@ -14,15 +12,18 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
 import java.util.Set;
 
 @RestController
 @RequestMapping("/auth")
+@CrossOrigin(origins = "http://localhost:5173")
 @Tag(name = "Authentication", description = "Endpoint para registro y login de usuarios")
 public class AuthController {
 
@@ -47,16 +48,18 @@ public class AuthController {
             description = "Crea nuevo usuario con rol ROLE_USER",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Usuario registrado"),
-                    @ApiResponse(responseCode = "400", description = "Usuario ya existe", content = @Content)
+                    @ApiResponse(responseCode = "400", description = "Correo ya existe", content = @Content)
             }
     )
-    public String register(@RequestBody AuthRequest request){
-        if (userRepository.findByUsername(request.getUsername()).isPresent()){
-            return  "Usuario ya existe";
+    public ResponseEntity<Map<String, String>> register(@RequestBody AuthRequest request){
+        if (userRepository.findByEmail(request.getEmail()).isPresent()){
+            return ResponseEntity
+                    .badRequest()
+                    .body(Map.of("message", "Correo ya existe"));
         }
 
         User user = new User();
-        user.setUsername(request.getUsername());
+        user.setEmail(request.getEmail());
         user.setPassword(passwordEncoder.encode(request.getPassword()));
 
         Role roleUser = roleRepository.findByName("ROLE_USER")
@@ -64,7 +67,7 @@ public class AuthController {
         user.setRoles(Set.of(roleUser));
 
         userRepository.save(user);
-        return "Usuario registrado";
+        return ResponseEntity.ok(Map.of("message", "Usuario registrado correctamente"));
     }
 
 
@@ -78,22 +81,23 @@ public class AuthController {
                     @ApiResponse(responseCode = "401", description = "Credenciales invalidas", content = @Content)
             }
     )
-    public String login(@RequestBody AuthRequest request){
+    public AuthResponse login(@RequestBody AuthRequest request){
         authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(request.getUsername(),request.getPassword())
+                new UsernamePasswordAuthenticationToken(request.getEmail(),request.getPassword())
         );
 
         // crea usuario con su rol de usuario
-        User user = userRepository.findByUsername(request.getUsername())
+        User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
 
         // devolver un jwt
-        return jwtUtil.generateToken(
+        String token = jwtUtil.generateToken(
                 org.springframework.security.core.userdetails.User
-                        .withUsername(user.getUsername())
+                        .withUsername(user.getEmail())
                         .password(user.getPassword())
                         .authorities(user.getRoles().stream().map(Role::getName).toArray(String[]::new))
                         .build()
         );
+        return new AuthResponse(token);
     }
 }

--- a/src/main/java/com/coworking/controller/ReservationController.java
+++ b/src/main/java/com/coworking/controller/ReservationController.java
@@ -2,10 +2,12 @@ package com.coworking.controller;
 
 import com.coworking.dto.ReservationRequest;
 import com.coworking.dto.ReservationResponse;
+import com.coworking.repository.UserRepository;
 import com.coworking.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
@@ -17,17 +19,23 @@ import java.util.List;
 public class ReservationController {
 
     private final ReservationService reservationService;
+    private final UserRepository userRepository;
 
-    public ReservationController(ReservationService reservationService) {
+    public ReservationController(ReservationService reservationService, UserRepository userRepository) {
         this.reservationService = reservationService;
+        this.userRepository = userRepository;
     }
 
     @PostMapping
     @Operation(summary = "Crear una reserva (USER o ADMIN)")
     public ReservationResponse create(@Valid @RequestBody ReservationRequest request, Authentication auth) {
         // auth.getName() nos da el username del usuario autenticado
-        Long userId = 1L; // 🔹 Temporal, luego lo obtendremos del userRepository usando auth.getName()
-        return reservationService.createReservation(userId, request);
+      String username = auth.getName();
+      Long userId = userRepository.findByUsername(username)
+              .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado: " +username))
+              .getId();
+
+    return reservationService.createReservation(userId, request);
     }
 
     @GetMapping

--- a/src/main/java/com/coworking/controller/ReservationController.java
+++ b/src/main/java/com/coworking/controller/ReservationController.java
@@ -1,0 +1,45 @@
+package com.coworking.controller;
+
+import com.coworking.dto.ReservationRequest;
+import com.coworking.dto.ReservationResponse;
+import com.coworking.service.ReservationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/reservations")
+@Tag(name = "Reservas", description = "Gestión de reservas de salas")
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    public ReservationController(ReservationService reservationService) {
+        this.reservationService = reservationService;
+    }
+
+    @PostMapping
+    @Operation(summary = "Crear una reserva (USER o ADMIN)")
+    public ReservationResponse create(@Valid @RequestBody ReservationRequest request, Authentication auth) {
+        // auth.getName() nos da el username del usuario autenticado
+        Long userId = 1L; // 🔹 Temporal, luego lo obtendremos del userRepository usando auth.getName()
+        return reservationService.createReservation(userId, request);
+    }
+
+    @GetMapping
+    @Operation(summary = "Listar todas las reservas")
+    public List<ReservationResponse> getAll() {
+        return reservationService.getAllReservations();
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar una reserva (solo ADMIN o dueño)")
+    public void delete(@PathVariable Long id) {
+        reservationService.deleteReservation(id);
+    }
+}
+

--- a/src/main/java/com/coworking/controller/ReservationController.java
+++ b/src/main/java/com/coworking/controller/ReservationController.java
@@ -31,8 +31,8 @@ public class ReservationController {
     public ReservationResponse create(@Valid @RequestBody ReservationRequest request, Authentication auth) {
         // auth.getName() nos da el username del usuario autenticado
       String username = auth.getName();
-      Long userId = userRepository.findByUsername(username)
-              .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado: " +username))
+      Long userId = userRepository.findByEmail(username)
+              .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado: " + username))
               .getId();
 
     return reservationService.createReservation(userId, request);
@@ -45,7 +45,7 @@ public class ReservationController {
     }
 
     @DeleteMapping("/{id}")
-    @Operation(summary = "Eliminar una reserva (solo ADMIN o dueño)")
+    @Operation(summary = "Eliminar una reserva (solo ADMIN)")
     public void delete(@PathVariable Long id) {
         reservationService.deleteReservation(id);
     }

--- a/src/main/java/com/coworking/controller/RoomController.java
+++ b/src/main/java/com/coworking/controller/RoomController.java
@@ -1,0 +1,69 @@
+package com.coworking.controller;
+
+import com.coworking.dto.RoomDto;
+import com.coworking.service.RoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import javax.swing.plaf.SeparatorUI;
+import java.util.List;
+
+@RestController
+@RequestMapping("api/rooms")
+@Tag(name = "Rooms", description = "Gestion de salas de coworking")
+@AllArgsConstructor
+public class RoomController {
+    private final RoomService roomService;
+
+    // listar
+    @GetMapping
+    @Operation(summary = "Listar todas las salas")
+    public List<RoomDto> getAllRoom(){
+        return roomService.getAllRooms();
+    }
+
+    //buscar por id
+    @GetMapping("/{id}")
+    @Operation(summary = "Obtener salas por id")
+    public ResponseEntity<RoomDto> getRoomById(@PathVariable Long id){
+        return roomService.getRoomById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+    //Crear
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Crear una nueva sala(solo ADMIN")
+    public ResponseEntity<RoomDto> createRoom(@RequestBody RoomDto dto){
+        return ResponseEntity.ok(roomService.createRoom(dto));
+    }
+
+    //Actualizar
+    @PostMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Actualizar sala existente(solo ADMIN)")
+    public ResponseEntity<RoomDto> actualizarRoom(@PathVariable Long id, @RequestBody RoomDto dto){
+        return roomService.updateRoom(id, dto)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    //eliminar
+    @DeleteMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Eliminar sala (solo ADMIN")
+    public ResponseEntity<RoomDto> deleteRoom(@PathVariable Long id){
+        return roomService.deleteRoom(id)
+                ?ResponseEntity.noContent().build()
+                :ResponseEntity.notFound().build();
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/coworking/dto/AuthRequest.java
+++ b/src/main/java/com/coworking/dto/AuthRequest.java
@@ -8,8 +8,8 @@ import lombok.Setter;
 @Getter
 public class AuthRequest {
 
-    @Schema(description = "Nombre de usuario", example = "user1")
-    private String username;
+    @Schema(description = "Correo electronico de usuario", example = "user1@gmail.com")
+    private String email;
 
     @Schema(description = "Contraseña del usuario", example = "12345678")
     private String password;

--- a/src/main/java/com/coworking/dto/LoginRequest.java
+++ b/src/main/java/com/coworking/dto/LoginRequest.java
@@ -3,5 +3,5 @@ package com.coworking.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Request para login")
-public record LoginRequest(String username, String password) {
+public record LoginRequest(String email, String password) {
 }

--- a/src/main/java/com/coworking/dto/RegisterRequest.java
+++ b/src/main/java/com/coworking/dto/RegisterRequest.java
@@ -3,5 +3,5 @@ package com.coworking.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Request para registrar un usuario")
-public record RegisterRequest(String username, String password, String role) {
+public record RegisterRequest(String email, String password, String role) {
 }

--- a/src/main/java/com/coworking/dto/ReservationRequest.java
+++ b/src/main/java/com/coworking/dto/ReservationRequest.java
@@ -1,0 +1,23 @@
+package com.coworking.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter
+public class ReservationRequest {
+
+    @NotNull(message = "El ID de la sala es obligatorio")
+    private Long roomId;
+
+    @NotNull(message = "La fecha de inicio es obligatoria")
+    private LocalDateTime startAt;
+
+    @NotNull(message = "La fecha de finalización es obligatoria")
+    private LocalDateTime endAt;
+
+    private String note;
+
+}

--- a/src/main/java/com/coworking/dto/ReservationResponse.java
+++ b/src/main/java/com/coworking/dto/ReservationResponse.java
@@ -1,0 +1,17 @@
+package com.coworking.dto;
+
+import com.coworking.model.ReservationStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter
+public class ReservationResponse {
+    private Long id;
+    private String roomName;
+    private String username;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private ReservationStatus status;
+}

--- a/src/main/java/com/coworking/dto/RoomDto.java
+++ b/src/main/java/com/coworking/dto/RoomDto.java
@@ -1,0 +1,23 @@
+package com.coworking.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+public class RoomDto {
+
+    @Schema(description = "ID de la sala", example = "1")
+    private Long id;
+
+    @Schema(description = "nombre de la sala", example = "Sala principal")
+    private String name;
+
+    @Schema(description = " descripcion de la sala", example = "espacio con pizarra y aire acondicionado")
+    private String description;
+
+    @Schema(description = "capacidad maxima", example = "6")
+    private Integer capacity;
+
+    @Schema(description = "Disponibilidad actual", example = "true")
+    private boolean available;
+}

--- a/src/main/java/com/coworking/exception/ReservationConflictException.java
+++ b/src/main/java/com/coworking/exception/ReservationConflictException.java
@@ -1,0 +1,12 @@
+package com.coworking.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ReservationConflictException extends RuntimeException{
+
+    public ReservationConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/coworking/model/Reservation.java
+++ b/src/main/java/com/coworking/model/Reservation.java
@@ -1,0 +1,42 @@
+package com.coworking.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reservations")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Reservation {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(optional = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(nullable = false)
+    private LocalDateTime endAt;
+
+    private String notes;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReservationStatus status = ReservationStatus.PENDING;
+
+}

--- a/src/main/java/com/coworking/model/ReservationStatus.java
+++ b/src/main/java/com/coworking/model/ReservationStatus.java
@@ -1,0 +1,7 @@
+package com.coworking.model;
+
+public enum ReservationStatus {
+    PENDING,
+    CONFIRMED,
+    CANCELLED
+}

--- a/src/main/java/com/coworking/model/Room.java
+++ b/src/main/java/com/coworking/model/Room.java
@@ -1,0 +1,30 @@
+package com.coworking.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "rooms")
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Room {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    @Column(nullable = false)
+    private Integer capacity;
+
+    private boolean available = true;
+
+
+}

--- a/src/main/java/com/coworking/model/User.java
+++ b/src/main/java/com/coworking/model/User.java
@@ -1,14 +1,17 @@
 package com.coworking.model;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.HashSet;
 import java.util.Set;
 
-@Setter
-@Getter
+@Setter @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Table(name = "users")
 public class User {
@@ -18,7 +21,7 @@ public class User {
     private Long id;
 
     @Column(unique = true, nullable = false)
-    private String username;
+    private String email;
     @Column(nullable = false)
     private String password;
 
@@ -30,15 +33,5 @@ public class User {
     )
 
     private Set<Role> roles = new HashSet<>();
-
-    public User() {
-    }
-
-    public User(Long id, String username, String password, Set<Role> roles) {
-        this.id = id;
-        this.username = username;
-        this.password = password;
-        this.roles = roles;
-    }
 
 }

--- a/src/main/java/com/coworking/repository/ReservationRepository.java
+++ b/src/main/java/com/coworking/repository/ReservationRepository.java
@@ -5,10 +5,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
+    //verificar si se cruzan horarios
     List<Reservation> findByRoomIdAndStartAtLessThanEndAtGreaterThan(
             Long roomId, LocalDateTime end, LocalDateTime start
+    );
+
+   //verificar si tiene reserva identica
+    Optional<Reservation> findByIdAndRoomIdStartAtAndEndAt(
+            Long userId, Long roomId, LocalDateTime start, LocalDateTime end
     );
 }

--- a/src/main/java/com/coworking/repository/ReservationRepository.java
+++ b/src/main/java/com/coworking/repository/ReservationRepository.java
@@ -10,12 +10,17 @@ import java.util.Optional;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
     //verificar si se cruzan horarios
-    List<Reservation> findByRoomIdAndStartAtLessThanEndAtGreaterThan(
-            Long roomId, LocalDateTime end, LocalDateTime start
+    List<Reservation> findByRoomIdAndStartAtLessThanAndEndAtGreaterThan(
+            Long roomId,
+            LocalDateTime end,
+            LocalDateTime start
     );
 
    //verificar si tiene reserva identica
-    Optional<Reservation> findByIdAndRoomIdStartAtAndEndAt(
-            Long userId, Long roomId, LocalDateTime start, LocalDateTime end
-    );
+   Optional<Reservation> findByUserIdAndRoomIdAndStartAtAndEndAt(
+           Long userId,
+           Long roomId,
+           LocalDateTime start,
+           LocalDateTime end
+   );
 }

--- a/src/main/java/com/coworking/repository/ReservationRepository.java
+++ b/src/main/java/com/coworking/repository/ReservationRepository.java
@@ -1,0 +1,14 @@
+package com.coworking.repository;
+
+import com.coworking.model.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    List<Reservation> findByRoomIdAndStartAtLessThanEndAtGreaterThan(
+            Long roomId, LocalDateTime end, LocalDateTime start
+    );
+}

--- a/src/main/java/com/coworking/repository/RoomRepository.java
+++ b/src/main/java/com/coworking/repository/RoomRepository.java
@@ -1,0 +1,7 @@
+package com.coworking.repository;
+
+import com.coworking.model.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+}

--- a/src/main/java/com/coworking/repository/UserRepository.java
+++ b/src/main/java/com/coworking/repository/UserRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/coworking/service/CustomUserDetailsService.java
+++ b/src/main/java/com/coworking/service/CustomUserDetailsService.java
@@ -18,12 +18,12 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado"));
 
         return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getUsername())
+                .username(user.getEmail())
                 .password(user.getPassword()) //incriptada
                 .authorities(user.getRoles().stream().map(Role::getName).toArray(String[]::new))
                 .build();

--- a/src/main/java/com/coworking/service/ReservationService.java
+++ b/src/main/java/com/coworking/service/ReservationService.java
@@ -1,0 +1,106 @@
+package com.coworking.service;
+
+
+import com.coworking.dto.ReservationRequest;
+import com.coworking.dto.ReservationResponse;
+import com.coworking.exception.ReservationConflictException;
+import com.coworking.model.Reservation;
+import com.coworking.model.ReservationStatus;
+import com.coworking.model.Room;
+import com.coworking.model.User;
+import com.coworking.repository.ReservationRepository;
+import com.coworking.repository.RoomRepository;
+import com.coworking.repository.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final RoomRepository roomRepository;
+    private final UserRepository userRepository;
+
+    public ReservationResponse createReservation(Long userId, ReservationRequest request){
+        Room room = roomRepository.findById(request.getRoomId())
+                .orElseThrow(() -> new RuntimeException("Sala no encontrada"));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+
+        LocalDateTime start = request.getStartAt();
+        LocalDateTime end = request.getEndAt();
+
+        //validaciones
+        if (!start.isBefore(end)) throw new
+                ReservationConflictException("La hora de inicio debe ser anterior a la hora de fin");
+
+        if (start.toLocalTime().isBefore(LocalTime.of(8,0)) ||
+                end.toLocalTime().isAfter(LocalTime.of(20, 0)))
+            throw new ReservationConflictException("Las reservas deben estar entre 08:00 y 20:00");
+
+        if (end.minusHours(8).isAfter(start))
+            throw new ReservationConflictException("La duración máxima de una reserva es de 8 horas");
+
+
+        //verificacion de cruce de horarios
+
+        List<Reservation> overlapping =reservationRepository
+                .findByRoomIdAndStartAtLessThanEndAtGreaterThan(room.getId(), end, start);
+
+        if (!overlapping.isEmpty())
+            throw  new ReservationConflictException("La sala ya está reservada en ese horario");
+
+        // verificacion de reserva duplicada
+        if (reservationRepository.findByIdAndRoomIdStartAtAndEndAt(user.getId(), room.getId(), start , end).isPresent())
+            throw new ReservationConflictException("Ya tienes una reserva igual");
+
+
+        //crear reserva
+        Reservation reservation = new Reservation();
+        reservation.setRoom(room);
+        reservation.setUser(user);
+        reservation.setStartAt(start);
+        reservation.setEndAt(end);
+        reservation.setStatus(ReservationStatus.CONFIRMED);
+
+        Reservation saved = reservationRepository.save(reservation);
+        return mapToResponse(saved);
+
+
+
+    }
+
+    private ReservationResponse mapToResponse(Reservation reservation) {
+        ReservationResponse dto = new ReservationResponse();
+        dto.setId(reservation.getId());
+        dto.setRoomName(reservation.getRoom().getName());
+        dto.setUsername(reservation.getUser().getUsername());
+        dto.setStartAt(reservation.getStartAt());
+        dto.setEndAt(reservation.getEndAt());
+        dto.setStatus(reservation.getStatus());
+        return dto;
+    }
+
+    public List<ReservationResponse> getAllReservations(){
+        return  reservationRepository.findAll().stream()
+                .map(this::mapToResponse)
+                .collect(Collectors.toList());
+    }
+
+    public void deleteReservation(Long id){
+        if (!reservationRepository.existsById(id))
+            throw new RuntimeException("Reserva no encontrada");
+
+        reservationRepository.deleteById(id);
+    }
+
+
+
+}

--- a/src/main/java/com/coworking/service/ReservationService.java
+++ b/src/main/java/com/coworking/service/ReservationService.java
@@ -35,30 +35,19 @@ public class ReservationService {
                 .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
 
         LocalDateTime start = request.getStartAt();
-        LocalDateTime end = request.getEndAt();
-
-        //validaciones
-        if (!start.isBefore(end)) throw new
-                ReservationConflictException("La hora de inicio debe ser anterior a la hora de fin");
-
-        if (start.toLocalTime().isBefore(LocalTime.of(8,0)) ||
-                end.toLocalTime().isAfter(LocalTime.of(20, 0)))
-            throw new ReservationConflictException("Las reservas deben estar entre 08:00 y 20:00");
-
-        if (end.minusHours(8).isAfter(start))
-            throw new ReservationConflictException("La duración máxima de una reserva es de 8 horas");
+        LocalDateTime end = getLocalDateTime(request, start);
 
 
         //verificacion de cruce de horarios
 
         List<Reservation> overlapping =reservationRepository
-                .findByRoomIdAndStartAtLessThanEndAtGreaterThan(room.getId(), end, start);
+                .findByRoomIdAndStartAtLessThanAndEndAtGreaterThan(room.getId(), end, start);
 
         if (!overlapping.isEmpty())
             throw  new ReservationConflictException("La sala ya está reservada en ese horario");
 
         // verificacion de reserva duplicada
-        if (reservationRepository.findByIdAndRoomIdStartAtAndEndAt(user.getId(), room.getId(), start , end).isPresent())
+        if (reservationRepository.findByUserIdAndRoomIdAndStartAtAndEndAt(user.getId(), room.getId(), start , end).isPresent())
             throw new ReservationConflictException("Ya tienes una reserva igual");
 
 
@@ -75,6 +64,22 @@ public class ReservationService {
 
 
 
+    }
+
+    private static LocalDateTime getLocalDateTime(ReservationRequest request, LocalDateTime start) {
+        LocalDateTime end = request.getEndAt();
+
+        //validaciones
+        if (!start.isBefore(end)) throw new
+                ReservationConflictException("La hora de inicio debe ser anterior a la hora de fin");
+
+        if (start.toLocalTime().isBefore(LocalTime.of(8,0)) ||
+                end.toLocalTime().isAfter(LocalTime.of(20, 0)))
+            throw new ReservationConflictException("Las reservas deben estar entre 08:00 y 20:00");
+
+        if (end.minusHours(8).isAfter(start))
+            throw new ReservationConflictException("La duración máxima de una reserva es de 8 horas");
+        return end;
     }
 
     private ReservationResponse mapToResponse(Reservation reservation) {

--- a/src/main/java/com/coworking/service/RoomService.java
+++ b/src/main/java/com/coworking/service/RoomService.java
@@ -1,0 +1,80 @@
+package com.coworking.service;
+
+import com.coworking.dto.RoomDto;
+import com.coworking.model.Room;
+import com.coworking.repository.RoomRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.security.PrivateKey;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class RoomService {
+
+    private final RoomRepository roomRepository;
+
+    //
+    private RoomDto mapToDto(Room room){
+        RoomDto dto = new RoomDto();
+        dto.setId(room.getId());
+        dto.setName(room.getName());
+        dto.setDescription(room.getDescription());
+        dto.setCapacity(room.getCapacity());
+        dto.setAvailable(room.isAvailable());
+        return dto;
+    }
+
+    private Room mapToEntity(RoomDto dto){
+        Room room = new Room();
+        room.setId(dto.getId());
+        room.setName(dto.getName());
+        room.setDescription(dto.getDescription());
+        room.setCapacity(dto.getCapacity());
+        room.setAvailable(dto.isAvailable());
+        return room;
+    }
+
+    //devuelve todas las salas en formato dto 
+    public List<RoomDto> getAllRooms(){
+        return roomRepository.findAll().stream()
+                .map(this::mapToDto) //cada entidad se convierte en DTO
+                .collect(Collectors.toList());
+    }
+
+    //busca por id y convierte a Dto
+    public Optional<RoomDto> getRoomById(Long id){
+        return roomRepository.findById(id).map(this::mapToDto);
+    }
+
+    //crear sala
+    public RoomDto createRoom(RoomDto dto){
+        Room room = mapToEntity(dto); //DTO a entidad
+        return mapToDto(roomRepository.save(room)); //guardarlo(DB) y devolver como dto
+
+    }
+
+    // Busca la sala y actualiza campos
+    public Optional<RoomDto> updateRoom(Long id, RoomDto dto){
+        return roomRepository.findById(id).map(existing ->{
+           existing.setName(dto.getName());
+           existing.setDescription(dto.getDescription());
+           existing.setCapacity(dto.getCapacity());
+           existing.setAvailable(dto.isAvailable());
+           return mapToDto(roomRepository.save(existing));
+        });
+    }
+
+    //elimino la sala si existe
+
+    public boolean deleteRoom(Long id){
+        if (roomRepository.existsById(id)){
+            roomRepository.deleteById(id);
+            return  true;
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/coworking/ReservationServiceTest.java
+++ b/src/test/java/com/coworking/ReservationServiceTest.java
@@ -1,0 +1,127 @@
+package com.coworking;
+
+import com.coworking.dto.ReservationRequest;
+import com.coworking.dto.ReservationResponse;
+import com.coworking.exception.ReservationConflictException;
+import com.coworking.model.Reservation;
+import com.coworking.model.ReservationStatus;
+import com.coworking.model.Room;
+import com.coworking.model.User;
+import com.coworking.repository.ReservationRepository;
+import com.coworking.repository.RoomRepository;
+import com.coworking.repository.UserRepository;
+import com.coworking.service.ReservationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ReservationServiceTest {
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private RoomRepository roomRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ReservationService reservationService;
+
+    private User user;
+    private Room room;
+    private ReservationRequest request;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        user = new User();
+        user.setId(1L);
+        user.setUsername("dayana");
+
+        room = new Room();
+        room.setId(2L);
+        room.setName("Sala A");
+
+        request = new ReservationRequest();
+        request.setRoomId(room.getId());
+        request.setStartAt(LocalDateTime.of(2025, 10, 1, 10, 0));
+        request.setEndAt(LocalDateTime.of(2025, 10, 1, 12, 0));
+    }
+
+    @Test
+    void createReservation_success() {
+        // Given
+        when(roomRepository.findById(room.getId())).thenReturn(Optional.of(room));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(reservationRepository.findByRoomIdAndStartAtLessThanAndEndAtGreaterThan(
+                anyLong(), any(), any())
+        ).thenReturn(Collections.emptyList());
+        when(reservationRepository.findByUserIdAndRoomIdAndStartAtAndEndAt(
+                anyLong(), anyLong(), any(), any())
+        ).thenReturn(Optional.empty());
+
+        Reservation saved = new Reservation();
+        saved.setId(99L);
+        saved.setRoom(room);
+        saved.setUser(user);
+        saved.setStartAt(request.getStartAt());
+        saved.setEndAt(request.getEndAt());
+        saved.setStatus(ReservationStatus.CONFIRMED);
+
+        when(reservationRepository.save(any(Reservation.class))).thenReturn(saved);
+
+        // When
+        ReservationResponse response = reservationService.createReservation(user.getId(), request);
+
+        // Then
+        assertNotNull(response);
+        assertEquals("Sala A", response.getRoomName());
+        assertEquals("dayana", response.getUsername());
+        assertEquals(ReservationStatus.CONFIRMED, response.getStatus());
+        verify(reservationRepository, times(1)).save(any(Reservation.class));
+    }
+
+    @Test
+    void createReservation_conflictOverlap_throwsException() {
+        // Given
+        when(roomRepository.findById(room.getId())).thenReturn(Optional.of(room));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+        List<Reservation> overlapping = List.of(new Reservation());
+        when(reservationRepository.findByRoomIdAndStartAtLessThanAndEndAtGreaterThan(
+                anyLong(), any(), any())
+        ).thenReturn(overlapping);
+
+        // When + Then
+        assertThrows(ReservationConflictException.class,
+                () -> reservationService.createReservation(user.getId(), request));
+    }
+
+    @Test
+    void createReservation_duplicateReservation_throwsException() {
+        // Given
+        when(roomRepository.findById(room.getId())).thenReturn(Optional.of(room));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(reservationRepository.findByRoomIdAndStartAtLessThanAndEndAtGreaterThan(
+                anyLong(), any(), any())
+        ).thenReturn(Collections.emptyList());
+        when(reservationRepository.findByUserIdAndRoomIdAndStartAtAndEndAt(
+                anyLong(), anyLong(), any(), any())
+        ).thenReturn(Optional.of(new Reservation()));
+
+        // When + Then
+        assertThrows(ReservationConflictException.class,
+                () -> reservationService.createReservation(user.getId(), request));
+    }
+}

--- a/src/test/java/com/coworking/RoomServiceTest.java
+++ b/src/test/java/com/coworking/RoomServiceTest.java
@@ -1,0 +1,113 @@
+package com.coworking;
+
+import com.coworking.dto.RoomDto;
+import com.coworking.model.Room;
+import com.coworking.repository.RoomRepository;
+import com.coworking.service.RoomService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RoomServiceTest {
+
+    @Mock
+    private RoomRepository roomRepository;
+
+    @InjectMocks
+    private RoomService roomService;
+
+    private Room room;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        room = new Room();
+        room.setId(1L);
+        room.setName("Sala 1");
+        room.setDescription("Sala grande");
+        room.setCapacity(10);
+        room.setAvailable(true);
+    }
+
+    @Test
+    void getAllRooms_returnsList() {
+        when(roomRepository.findAll()).thenReturn(List.of(room));
+
+        List<RoomDto> rooms = roomService.getAllRooms();
+
+        assertEquals(1, rooms.size());
+        assertEquals("Sala 1", rooms.getFirst().getName());
+    }
+
+    @Test
+    void getRoomById_returnsRoomDto() {
+        when(roomRepository.findById(1L)).thenReturn(Optional.of(room));
+
+        Optional<RoomDto> result = roomService.getRoomById(1L);
+
+        assertTrue(result.isPresent());
+        assertEquals("Sala 1", result.get().getName());
+    }
+
+    @Test
+    void createRoom_savesAndReturnsDto() {
+        RoomDto dto = new RoomDto();
+        dto.setName("Sala nueva");
+        dto.setDescription("Pequeña");
+        dto.setCapacity(5);
+        dto.setAvailable(true);
+
+        when(roomRepository.save(any(Room.class))).thenReturn(room);
+
+        RoomDto result = roomService.createRoom(dto);
+
+        assertNotNull(result);
+        assertEquals("Sala 1", result.getName());
+    }
+
+    @Test
+    void updateRoom_updatesExistingRoom() {
+        when(roomRepository.findById(1L)).thenReturn(Optional.of(room));
+        when(roomRepository.save(any(Room.class))).thenReturn(room);
+
+        RoomDto dto = new RoomDto();
+        dto.setName("Sala modificada");
+        dto.setDescription("Actualizada");
+        dto.setCapacity(15);
+        dto.setAvailable(false);
+
+        Optional<RoomDto> result = roomService.updateRoom(1L, dto);
+
+        assertTrue(result.isPresent());
+        assertEquals("Sala modificada", result.get().getName());
+    }
+
+    @Test
+    void deleteRoom_existingRoom_returnsTrue() {
+        when(roomRepository.existsById(1L)).thenReturn(true);
+
+        boolean deleted = roomService.deleteRoom(1L);
+
+        assertTrue(deleted);
+        verify(roomRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void deleteRoom_nonExistingRoom_returnsFalse() {
+        when(roomRepository.existsById(1L)).thenReturn(false);
+
+        boolean deleted = roomService.deleteRoom(1L);
+
+        assertFalse(deleted);
+        verify(roomRepository, never()).deleteById(anyLong());
+    }
+}
+


### PR DESCRIPTION
Se refactoriza la lógica de autenticación y registro de usuarios para utilizar `email` en lugar de `username` como identificador principal.  
Este cambio mejora la experiencia del usuario Closes #26 
