### PR TITLE
Fix/39 enviar correo desde contactarnos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>

--- a/src/main/java/com/coworking/config/SecurityConfig.java
+++ b/src/main/java/com/coworking/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.coworking.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -34,7 +35,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(request -> {
                     var corsConfiguration = new org.springframework.web.cors.CorsConfiguration();
-                    corsConfiguration.setAllowedOrigins(List.of("http://localhost:5173"));
+                    corsConfiguration.setAllowedOriginPatterns(List.of("*"));
                     corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
                     corsConfiguration.setAllowedHeaders(List.of("*"));
                     corsConfiguration.setAllowCredentials(true);
@@ -43,6 +44,7 @@ public class SecurityConfig {
                 .exceptionHandling(ex ->ex.authenticationEntryPoint(authenticationEntryPoint))
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/contact").permitAll()
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers(
                                 "/swagger-ui/**",

--- a/src/main/java/com/coworking/controller/ContactController.java
+++ b/src/main/java/com/coworking/controller/ContactController.java
@@ -1,0 +1,28 @@
+package com.coworking.controller;
+
+import com.coworking.dto.ContactRequest;
+import com.coworking.service.ContactService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/contact")
+@Tag(name = "Contact", description = "Endpoint para formulario de contact")
+@RequiredArgsConstructor
+public class ContactController {
+    private final ContactService contactService;
+
+    @PostMapping
+    public ResponseEntity<?> SendContact(@Valid @RequestBody ContactRequest request){
+        contactService.sendContactEmail(request);
+        return ResponseEntity.ok(
+                Map.of("message", "Mensaje enviado correctamente")
+        );
+    }
+
+}

--- a/src/main/java/com/coworking/dto/ContactRequest.java
+++ b/src/main/java/com/coworking/dto/ContactRequest.java
@@ -1,0 +1,24 @@
+package com.coworking.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@Schema(description = "Request para contact")
+public class ContactRequest {
+
+    @NotBlank(message = "El nombre es obligatorio")
+    private String name;
+
+    @NotBlank(message = "El correo es obligatorio")
+    @Email(message = "Formato de correo inválido")
+    private String email;
+
+    @NotBlank(message = "El mensaje es obligatorio")
+    @Size(min = 10, message = "El mensaje debe tener al menos 10 caracteres")
+    private String message;
+}

--- a/src/main/java/com/coworking/service/ContactService.java
+++ b/src/main/java/com/coworking/service/ContactService.java
@@ -1,0 +1,29 @@
+package com.coworking.service;
+
+import com.coworking.dto.ContactRequest;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class ContactService {
+
+    private final JavaMailSender mailSender;
+
+
+    public void sendContactEmail(@Valid ContactRequest request) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom("CoworkingWeb <relaxation.comes@gmail.com>");
+        message.setTo("dc8848349@gmail.com");
+        message.setSubject("Contactanos Coworking Web");
+        message.setText(
+                "Nombre: " + request.getName() + "\nEmail: " + request.getEmail() + "\nMensaje:\n" + request.getMessage()
+
+        );
+
+        mailSender.send(message);
+    }
+}


### PR DESCRIPTION
Este PR agrega el endpoint de contacto y la configuración de envío de correos utilizando Gmail SMTP con App Password y seguridad 2FA.

Cambios:

- Endpoint POST /contact
- Servicio de envío de correos con JavaMailSender
- Corrección de configuración CORS (allowCredentials + origins explícitos)
- Mensaje de confirmación al frontend