### PR TITLE
fix: ajustar validación minima del mensaje en contacto

### DIFF
--- a/src/main/java/com/coworking/dto/ContactRequest.java
+++ b/src/main/java/com/coworking/dto/ContactRequest.java
@@ -19,6 +19,6 @@ public class ContactRequest {
     private String email;
 
     @NotBlank(message = "El mensaje es obligatorio")
-    @Size(min = 10, message = "El mensaje debe tener al menos 10 caracteres")
+    @Size(min = 6, message = "El mensaje debe tener al menos 6 caracteres")
     private String message;
 }


### PR DESCRIPTION
Se ajustó la validación mínima del mensaje en el formulario de contacto de 10 a 6 caracteres para mejorar la experiencia de usuario.