### PR TITLE
35 oauth con google

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,12 @@
 			<artifactId>spring-boot-starter-mail</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.google.api-client</groupId>
+			<artifactId>google-api-client</artifactId>
+			<version>2.2.0</version>
+		</dependency>
+
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/coworking/config/SecurityConfig.java
+++ b/src/main/java/com/coworking/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
                                 "/swagger-ui.html"
 
                         ).permitAll()
+                        .requestMatchers("/auth/google").permitAll()
                         .requestMatchers("/api/hello").permitAll()
                         .requestMatchers("/uploads/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/coworking/controller/AuthController.java
+++ b/src/main/java/com/coworking/controller/AuthController.java
@@ -11,6 +11,7 @@ import com.coworking.repository.RoleRepository;
 import com.coworking.repository.UserRepository;
 
 import com.coworking.service.EmailService;
+import com.coworking.service.GoogleAuthService;
 import com.coworking.service.PasswordResetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -20,6 +21,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.Authenticator;
 import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -54,7 +56,7 @@ public class AuthController {
     private final EmailService emailService;
     private final PasswordResetTokenRepository resetTokenRepository;
     private final PasswordResetService passwordResetService;
-
+    private final GoogleAuthService googleAuthService;
     private  final JwtUtil jwtUtil;
 
     //REGISTER
@@ -295,5 +297,12 @@ public class AuthController {
         );
     }
 
+    //google auth
+    @PostMapping("/auth/google")
+    public ResponseEntity<AuthResponse> googleAuth(@Valid @RequestBody GoogleAuthRequest request){
 
+        return ResponseEntity.ok(
+                googleAuthService.authenticate(request.getAccessToken())
+        );
+    }
 }

--- a/src/main/java/com/coworking/dto/GoogleAuthRequest.java
+++ b/src/main/java/com/coworking/dto/GoogleAuthRequest.java
@@ -1,0 +1,12 @@
+package com.coworking.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GoogleAuthRequest {
+    private String accessToken;
+}

--- a/src/main/java/com/coworking/dto/GoogleUserInfo.java
+++ b/src/main/java/com/coworking/dto/GoogleUserInfo.java
@@ -1,0 +1,15 @@
+package com.coworking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GoogleUserInfo {
+    private String sub;
+    private String email;
+    private String name;
+    private Boolean email_verified;
+}

--- a/src/main/java/com/coworking/service/GoogleAuthService.java
+++ b/src/main/java/com/coworking/service/GoogleAuthService.java
@@ -1,0 +1,117 @@
+package com.coworking.service;
+
+import com.coworking.dto.AuthResponse;
+import com.coworking.dto.GoogleUserInfo;
+import com.coworking.model.Role;
+import com.coworking.model.User;
+import com.coworking.repository.RoleRepository;
+import com.coworking.repository.UserRepository;
+import com.coworking.security.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleAuthService {
+
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final JwtUtil jwtUtil;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public AuthResponse authenticate(String accessToken){
+        GoogleUserInfo googleUser = getUserInfo(accessToken);
+
+        if (googleUser == null || !Boolean.TRUE.equals(googleUser.getEmail_verified())) {
+            throw new RuntimeException("Token de Google inválido");
+        }
+
+        User user = userRepository.findByEmail(googleUser.getEmail())
+                .orElseGet(() -> registerGoogleUser(googleUser.getEmail(), googleUser.getName()));
+
+        UserDetails userDetails =
+                org.springframework.security.core.userdetails.User.builder()
+                        .username(user.getEmail())
+                        .password("")
+                        .authorities(
+                                user.getRoles().stream()
+                                        .map(Role::getName)
+                                        .toArray(String[]::new)
+                        )
+                        .build();
+
+        String token = jwtUtil.generateToken(userDetails, user.getUsername());
+
+        String role = user.getRoles().stream()
+                .findFirst()
+                .map(Role::getName)
+                .orElse("ROLE_USER");
+        return new AuthResponse(token, user.getUsername(), role);
+    }
+
+    private GoogleUserInfo getUserInfo(String accessToken) {
+        String url = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<GoogleUserInfo> response =
+                restTemplate.exchange(
+                        url,
+                        HttpMethod.GET,
+                        entity,
+                        GoogleUserInfo.class
+                );
+
+        return response.getBody();
+
+    }
+
+    private User registerGoogleUser(String email, String name) {
+        Role role = roleRepository.findByName("ROLE_USER")
+                .orElseThrow(() -> new RuntimeException("Rol USER no existe"));
+
+        User user = new User();
+        user.setEmail(email);
+        user.setUsername(name);
+        user.setEnabled(true); // verifico email
+        user.getRoles().add(role);
+
+        return userRepository.save(user);
+
+    }
+
+    /*private GoogleIdToken.Payload verifyToken(String idTokenString) {
+        try {
+            GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(
+                    new NetHttpTransport(),
+                    GsonFactory.getDefaultInstance()
+            )
+                    .setAudience(List.of(googleClientId))
+                    .build();
+
+            GoogleIdToken idToken = verifier.verify(idTokenString);
+
+            if (idToken == null){
+                throw new RuntimeException("Token de Google inválido");
+            }
+            return idToken.getPayload();
+
+
+        } catch (Exception e) {
+            throw new RuntimeException("Error validando token Google", e);
+        }
+    }*/
+}


### PR DESCRIPTION
Este PR integra autenticación con Google utilizando OAuth 2.0 para login y registro de usuarios, manteniendo compatibilidad con el flujo de autenticación actual basado en JWT.

Se utiliza `accessToken` debido al uso de OAuth moderno en SPA (React).
El backend valida el token con Google y genera un JWT propio, evitando dependencias directas en el frontend.