### PR TITLE
Fix orden inconsistente de salas y mejora de cobertura en eliminación

### DIFF
--- a/src/main/java/com/coworking/controller/RoomController.java
+++ b/src/main/java/com/coworking/controller/RoomController.java
@@ -81,6 +81,8 @@ public class RoomController {
         LocalTime s = LocalTime.parse(start);
         LocalTime e = LocalTime.parse(end);
 
+        if(s.isAfter(e)) return ResponseEntity.badRequest().build();
+
         List<RoomAvailabilityResponse> available = roomService.findAvailableRooms(d, s, e, people);
         return ResponseEntity.ok(available);
     }

--- a/src/main/java/com/coworking/repository/RoomRepository.java
+++ b/src/main/java/com/coworking/repository/RoomRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
     List<Room> findByCapacityGreaterThanEqual(Integer people);
+    List<Room> findByCapacityGreaterThanEqualOrderByCapacityAsc(Integer people);
 }

--- a/src/main/java/com/coworking/service/RoomService.java
+++ b/src/main/java/com/coworking/service/RoomService.java
@@ -7,6 +7,7 @@ import com.coworking.model.Room;
 import com.coworking.repository.ReservationRepository;
 import com.coworking.repository.RoomRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -14,6 +15,7 @@ import java.security.PrivateKey;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -26,6 +28,17 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final ReservationRepository reservationRepository;
     private final FileStorageService fileStorageService;
+
+    private RoomAvailabilityResponse mapToAvailability(Room room) {
+        RoomAvailabilityResponse r = new RoomAvailabilityResponse();
+        r.setId(room.getId());
+        r.setName(room.getName());
+        r.setCapacity(room.getCapacity());
+        r.setLocation(room.getLocation());
+        r.setImageUrl(room.getImageUrl());
+        r.setAvailable(room.isAvailable());
+        return r;
+    }
 
     private RoomDto mapToDto(Room room){
         RoomDto dto = new RoomDto();
@@ -55,8 +68,9 @@ public class RoomService {
         return room;
     }
 
+    //Obtener todas las salas
     public List<RoomDto> getAllRooms(){
-        return roomRepository.findAll()
+        return roomRepository.findAll(Sort.by(Sort.Direction.ASC, "capacity"))
                 .stream()
                 .map(this::mapToDto)
                 .collect(Collectors.toList());
@@ -78,6 +92,7 @@ public class RoomService {
         return mapToDto(saved);
     }
 
+    //actualizar salas
     public Optional<RoomDto> updateRoom(Long id, RoomDto dto){
         return roomRepository.findById(id).map(existing -> {
             existing.setName(dto.getName());
@@ -92,6 +107,7 @@ public class RoomService {
         });
     }
 
+    //Eliminar
     public boolean deleteRoom(Long id){
         if (!roomRepository.existsById(id)) return false;
         roomRepository.deleteById(id);
@@ -108,25 +124,13 @@ public class RoomService {
         LocalDateTime startDT = LocalDateTime.of(date, start);
         LocalDateTime endDT = LocalDateTime.of(date, end);
 
-        // Obtener salas con capacidad suficiente
-        List<Room> rooms = roomRepository.findByCapacityGreaterThanEqual(people);
+        // salas ordenadas por capacity desde DB
+        List<Room> rooms = roomRepository.findByCapacityGreaterThanEqualOrderByCapacityAsc(people);
 
         if (people == 1) {
-            List<Room> onePersonRooms = rooms.stream()
+           return rooms.stream()
                     .filter(r -> r.getCapacity() == 1)
-                    .collect(Collectors.toList());
-            return onePersonRooms.stream()
-                    .map(room -> {
-                        RoomAvailabilityResponse r = new RoomAvailabilityResponse();
-                        r.setId(room.getId());
-                        r.setName(room.getName());
-                        r.setCapacity(room.getCapacity());
-                        r.setLocation(room.getLocation());
-                        r.setImageUrl(room.getImageUrl());
-                        r.setAvailable(room.isAvailable());
-
-                        return r;
-                    })
+                   .map(this::mapToAvailability)
                     .collect(Collectors.toList());
         }
 
@@ -139,24 +143,13 @@ public class RoomService {
                 .map(r -> r.getRoom().getId())
                 .collect(Collectors.toSet());
 
-        // Filtrar salas que NO están ocupadas
+        // Filtrar soo las disponibles (Ya vienen ordenadas)
         List<Room> availableRooms = rooms.stream()
                 .filter(room -> !busyRoomIds.contains(room.getId()))
                 .toList();
 
-        // Convertir a DTO respuesta
         return availableRooms.stream()
-                .map(room -> {
-                    RoomAvailabilityResponse r = new RoomAvailabilityResponse();
-                    r.setId(room.getId());
-                    r.setName(room.getName());
-                    r.setCapacity(room.getCapacity());
-                    r.setLocation(room.getLocation());
-                    r.setImageUrl(room.getImageUrl());
-                    r.setAvailable(room.isAvailable());
-
-                    return r;
-                })
+                .map(this::mapToAvailability)
                 .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/coworking/resources/controller/RoomControllerSecurityTest.java
+++ b/src/test/java/com/coworking/resources/controller/RoomControllerSecurityTest.java
@@ -1,0 +1,55 @@
+package com.coworking.resources.controller;
+
+import com.coworking.controller.RoomController;
+import com.coworking.security.JwtUtil;
+import com.coworking.service.RoomService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+@WebMvcTest(RoomController.class)
+@AutoConfigureMockMvc
+public class RoomControllerSecurityTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RoomService roomService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+
+
+
+    //Usuario normal no puedde eliminar
+    @Test
+    @WithMockUser(roles = "USER")
+    public void usuarioNoAdmin_noPuedeEliminarSala() throws Exception {
+
+        mockMvc.perform(delete("/api/rooms/1"))
+                .andExpect(status().isForbidden());
+    }
+
+    // Admin si puede eliminar
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    public void adminPuedeEliminarSala() throws Exception {
+
+        when(roomService.deleteRoom(1L)).thenReturn(true);
+
+        mockMvc.perform(delete("/api/rooms/1")
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+    }
+
+}

--- a/src/test/java/com/coworking/resources/controller/RoomControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/RoomControllerTest.java
@@ -1,0 +1,52 @@
+package com.coworking.resources.controller;
+
+import com.coworking.controller.RoomController;
+import com.coworking.dto.RoomDto;
+import com.coworking.security.JwtUtil;
+import com.coworking.service.RoomService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RoomController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class RoomControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RoomService roomService;
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    void available_debeRetornar400_siStartEsMayorQueEnd() throws Exception {
+
+        mockMvc.perform(get("/api/rooms/available")
+                        .param("date", "2026-01-01")
+                        .param("start", "10:00")
+                        .param("end", "08:00")
+                        .param("people", "2"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getAllRooms_debeRetornar200() throws Exception {
+
+        when(roomService.getAllRooms())
+                .thenReturn(List.of(new RoomDto()));
+
+        mockMvc.perform(get("/api/rooms"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/coworking/resources/controller/RoomControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/RoomControllerTest.java
@@ -8,12 +8,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/com/coworking/resources/controller/RoomControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/RoomControllerTest.java
@@ -49,4 +49,25 @@ class RoomControllerTest {
         mockMvc.perform(get("/api/rooms"))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void adminEliminarSala_inexistente_devuelve404() throws Exception {
+
+        when(roomService.deleteRoom(1L)).thenReturn(false);
+
+        mockMvc.perform(delete("/api/rooms/1")
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    //Validacion de id numerico
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void eliminarSala_idInvalido_devuelve400() throws Exception {
+
+        mockMvc.perform(delete("/api/rooms/abc")
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/com/coworking/resources/service/RoomServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/RoomServiceTest.java
@@ -167,5 +167,23 @@ class RoomServiceTest {
         assertFalse(deleted);
         verify(roomRepository, never()).deleteById(anyLong());
     }
+    
+    @Test
+    void getAllRooms_debeRetornarOrdenAscendentePorCapacidad() {
+
+        Room r1 = new Room();
+        r1.setCapacity(6);
+
+        Room r2 = new Room();
+        r2.setCapacity(4);
+
+        when(roomRepository.findAll(any(Sort.class)))
+                .thenReturn(List.of(r2, r1));
+
+        List<RoomDto> result = roomService.getAllRooms();
+
+        assertEquals(4, result.get(0).getCapacity());
+        assertEquals(6, result.get(1).getCapacity());
+    }
 }
 

--- a/src/test/java/com/coworking/resources/service/RoomServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/RoomServiceTest.java
@@ -7,9 +7,12 @@ import com.coworking.service.FileStorageService;
 import com.coworking.service.RoomService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,6 +21,7 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class RoomServiceTest {
 
     @Mock
@@ -34,7 +38,7 @@ class RoomServiceTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
+        //MockitoAnnotations.openMocks(this);
 
         room = new Room();
         room.setId(1L);
@@ -63,7 +67,7 @@ class RoomServiceTest {
 
     @Test
     void getAllRooms_returnsList() {
-        when(roomRepository.findAll()).thenReturn(List.of(room));
+        when(roomRepository.findAll(any(Sort.class))).thenReturn(List.of(room));
 
         List<RoomDto> rooms = roomService.getAllRooms();
 


### PR DESCRIPTION
Este PR corrige el orden inconsistente en la lista de salas y mejora la cobertura de pruebas del endpoint de eliminación de salas.

Se asegura que las salas se ordenen de menor a mayor de forma consistente, sin importar la cantidad de registros.

**Cambios**

- Se revisó y corrigió el sort en el backend.
- Se garantiza orden ascendente consistente.
- Se asegura comportamiento estable sin importar la cantidad de datos.
- Se validó que el frontend reciba los datos correctamente ordenados.
- Se agrego test unitarios y se modifico test existentes de RoomController

**Tambien se agregaron test Necesarios** 

Se agregaron pruebas para el endpoint DELETE /api/rooms/{id}:

-  Admin puede eliminar una sala (204)
-  Admin recibe 404 cuando la sala no existe
-  Admin recibe 400 cuando el ID es inválido
-  Usuario no ADMIN recibe 403

Closes #60 