### PR TITLE
Feat/ajustar sala en calendar

### DIFF
--- a/src/main/java/com/coworking/controller/ReservationController.java
+++ b/src/main/java/com/coworking/controller/ReservationController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @RestController
@@ -61,10 +61,10 @@ public class ReservationController {
     public List<CalendarEventResponse> getCalendar(
             @RequestParam
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            LocalDateTime from,
+            Instant from,
             @RequestParam
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            LocalDateTime to
+            Instant to
     ){
         return reservationService.getCalendar(from, to);
     }

--- a/src/main/java/com/coworking/controller/RoomController.java
+++ b/src/main/java/com/coworking/controller/RoomController.java
@@ -12,7 +12,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @RestController
@@ -74,10 +74,10 @@ public class RoomController {
     public List<RoomAvailabilityResponse> getAvailability(
             @RequestParam
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            LocalDateTime start,
+            Instant start,
             @RequestParam
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            LocalDateTime end,
+            Instant end,
             @RequestParam Integer people
     ){
 

--- a/src/main/java/com/coworking/dto/CalendarEventResponse.java
+++ b/src/main/java/com/coworking/dto/CalendarEventResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter @Setter
 @AllArgsConstructor
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 public class CalendarEventResponse {
 
     private String title;
-    private LocalDateTime start;
-    private LocalDateTime end;
+    private Instant start;
+    private Instant end;
+    private Long roomId;
 }

--- a/src/main/java/com/coworking/dto/ReservationRequest.java
+++ b/src/main/java/com/coworking/dto/ReservationRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter @Setter
 public class ReservationRequest {
@@ -14,10 +14,10 @@ public class ReservationRequest {
     private Long roomId;
 
     @NotNull(message = "La fecha de inicio es obligatoria")
-    private LocalDateTime startAt;
+    private Instant startAt;
 
     @NotNull(message = "La fecha de finalización es obligatoria")
-    private LocalDateTime endAt;
+    private Instant endAt;
 
     @NotBlank
     private String note;

--- a/src/main/java/com/coworking/dto/ReservationResponse.java
+++ b/src/main/java/com/coworking/dto/ReservationResponse.java
@@ -4,14 +4,14 @@ import com.coworking.model.ReservationStatus;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter @Setter
 public class ReservationResponse {
     private Long id;
     private String roomName;
     private String username;
-    private LocalDateTime startAt;
-    private LocalDateTime endAt;
+    private Instant startAt;
+    private Instant endAt;
     private ReservationStatus status;
 }

--- a/src/main/java/com/coworking/model/Reservation.java
+++ b/src/main/java/com/coworking/model/Reservation.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "reservations")
@@ -28,10 +28,10 @@ public class Reservation {
     private User user;
 
     @Column(nullable = false)
-    private LocalDateTime startAt;
+    private Instant startAt;
 
     @Column(nullable = false)
-    private LocalDateTime endAt;
+    private Instant endAt;
 
     private String notes;
 

--- a/src/main/java/com/coworking/repository/ReservationRepository.java
+++ b/src/main/java/com/coworking/repository/ReservationRepository.java
@@ -4,7 +4,7 @@ import com.coworking.model.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,20 +14,20 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     //verificar si se cruzan horarios
     List<Reservation> findByRoomIdAndStartAtLessThanAndEndAtGreaterThan(
             Long roomId,
-            LocalDateTime end,
-            LocalDateTime start
+            Instant end,
+            Instant start
     );
 
    //verificar si tiene reserva identica
    Optional<Reservation> findByUserIdAndRoomIdAndStartAtAndEndAt(
            Long userId,
            Long roomId,
-           LocalDateTime start,
-           LocalDateTime end
+           Instant start,
+           Instant end
    );
 
     List<Reservation> findByStartAtLessThanAndEndAtGreaterThan(
-            LocalDateTime end,
-            LocalDateTime start);
+            Instant end,
+            Instant start);
 
 }

--- a/src/main/java/com/coworking/service/ReservationService.java
+++ b/src/main/java/com/coworking/service/ReservationService.java
@@ -15,9 +15,7 @@ import com.coworking.repository.UserRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.time.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,8 +34,11 @@ public class ReservationService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
 
-        LocalDateTime start = request.getStartAt();
-        LocalDateTime end = request.getEndAt();
+        Instant start = request.getStartAt();
+        Instant end = request.getEndAt();
+
+        System.out.println("START: " + start);
+        System.out.println("END: " + end);
 
         validateReservationTimes(start, end);
 
@@ -66,8 +67,8 @@ public class ReservationService {
         return mapToResponse(saved);
     }
 
-    private void validateReservationTimes(LocalDateTime start, LocalDateTime end){
-        LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
+    private void validateReservationTimes(Instant start, Instant end){
+        Instant now = Instant.now();
 
         // evitar horas pasadas
         if (start.isBefore(now)) {
@@ -78,11 +79,15 @@ public class ReservationService {
         if (!start.isBefore(end)) {
             throw new ReservationConflictException("La hora de inicio debe ser anterior a la de fin");
         }
+        // horario 07:00 - 20:00 EN HORA LOCAL
+        ZoneId zone = ZoneId.of("America/El_Salvador");
+
+        LocalTime startLocal = start.atZone(zone).toLocalTime();
+        LocalTime endLocal = end.atZone(zone).toLocalTime();
 
         // horario permitido
-        if (start.toLocalTime().isBefore(LocalTime.of(7,0)) ||
-                end.toLocalTime().isAfter(LocalTime.of(20,0))) {
-
+        if (startLocal.isBefore(LocalTime.of(7,0)) ||
+                endLocal.isAfter(LocalTime.of(20,0))) {
             throw new ReservationConflictException("Las reservas deben estar entre 07:00 y 20:00");
         }
 
@@ -118,8 +123,8 @@ public class ReservationService {
 
     //ver eventos en calendario
     public List<CalendarEventResponse> getCalendar(
-            LocalDateTime from,
-            LocalDateTime to
+            Instant from,
+            Instant to
     ){
         return reservationRepository
                 .findByStartAtLessThanAndEndAtGreaterThan(to, from)
@@ -127,7 +132,8 @@ public class ReservationService {
                 .map(r -> new CalendarEventResponse(
                          r.getRoom().getName(),
                          r.getStartAt(),
-                         r.getEndAt()
+                         r.getEndAt(),
+                         r.getRoom().getId()
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/coworking/service/RoomService.java
+++ b/src/main/java/com/coworking/service/RoomService.java
@@ -12,11 +12,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.security.PrivateKey;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.Comparator;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -132,8 +128,8 @@ public class RoomService {
     // ROOM AVAILABILITY
 
     public List<RoomAvailabilityResponse> getRoomsAvailability(
-            LocalDateTime start,
-            LocalDateTime end,
+            Instant start,
+           Instant end,
             Integer people
     ){
 

--- a/src/test/java/com/coworking/resources/controller/ReservationControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/ReservationControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -55,8 +56,8 @@ public class ReservationControllerTest {
 
         ReservationRequest request = new ReservationRequest();
         request.setRoomId(1L);
-        request.setStartAt(LocalDateTime.of(2025,10,1,10,0));
-        request.setEndAt(LocalDateTime.of(2025,10,1,12,0));
+        request.setStartAt(Instant.parse("2025-10-01T10:00:00Z"));
+        request.setEndAt(Instant.parse("2025-10-01T12:00:00Z"));
 
         User user = new User();
         user.setId(1L);

--- a/src/test/java/com/coworking/resources/service/ReservationServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/ReservationServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -55,8 +56,8 @@ class ReservationServiceTest {
 
         request = new ReservationRequest();
         request.setRoomId(room.getId());
-        request.setStartAt(LocalDateTime.of(2025, 10, 1, 10, 0));
-        request.setEndAt(LocalDateTime.of(2025, 10, 1, 12, 0));
+        request.setStartAt(Instant.parse("2025-10-01T10:00:00Z"));
+        request.setEndAt(Instant.parse("2025-10-01T12:00:00Z"));
     }
 
     @Test
@@ -127,9 +128,8 @@ class ReservationServiceTest {
     //Validacion de horario invalido
     @Test
     void createReservation_invalidHour_throwsException() {
-        request.setStartAt(LocalDateTime.of(2025,10,1,7,0));
-        request.setEndAt(LocalDateTime.of(2025,10,1,9,0));
-
+        request.setStartAt(Instant.parse("2025-10-01T10:00:00Z"));
+        request.setEndAt(Instant.parse("2025-10-01T12:00:00Z"));
         when(roomRepository.findById(room.getId())).thenReturn(Optional.of(room));
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
 


### PR DESCRIPTION
Este PR migra el manejo de fechas en el sistema de reservas de `LocalDateTime` a `Instant`, mejorando la consistencia en zonas horarias y la integración con el frontend.

### Cambios principales

* Refactor de fechas a `Instant` en:

  * RoomController
  * ReservationService
  * DTOs (ReservationResponse)
* endpoint `/availability` con soporte ISO-8601
* Validación de horario de reservas (07:00 - 20:00) en zona `America/El_Salvador`

### Testing

* Se ajustaron tests para soportar `Instant`
* Se validó creación de reservas dentro y fuera del horario permitido
