### PR TITLE
refactor/api-response-standard

### DIFF
--- a/src/main/java/com/coworking/auth/controller/AuthController.java
+++ b/src/main/java/com/coworking/auth/controller/AuthController.java
@@ -1,13 +1,9 @@
 package com.coworking.auth.controller;
 import com.coworking.auth.dto.*;
-import com.coworking.auth.model.VerificationToken;
 import com.coworking.auth.repository.VerificationTokenRepository;
 import com.coworking.auth.service.AuthService;
 import com.coworking.dto.common.ApiResponseDto;
-import com.coworking.exception.NotFoundException;
-import com.coworking.role.model.Role;
 import com.coworking.security.JwtUtil;
-import com.coworking.user.model.User;
 import com.coworking.role.repository.RoleRepository;
 import com.coworking.user.repository.UserRepository;
 
@@ -20,23 +16,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import com.coworking.exception.BadRequestException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/auth")
@@ -64,8 +51,9 @@ public class AuthController {
     )
     @PostMapping("/register")
     public ResponseEntity<ApiResponseDto<Void>> register(@Valid @RequestBody RegisterRequest request) {
+        String message = authService.register(request);
         return ResponseEntity.ok(
-                ApiResponseDto.success(authService.register(request))
+                ApiResponseDto.success(message, null)
         );
     }
     //VERIFY EMAIL
@@ -78,10 +66,10 @@ public class AuthController {
     //REENVIAR CORREO DE VERIFICACION
     @PostMapping("/resend-verification")
     public ResponseEntity<ApiResponseDto<String>> resendVerification(@RequestBody Map<String, String> request) {
+        String message = authService.resendVerification(request.get("email"));
+
         return ResponseEntity.ok(
-                ApiResponseDto.success(
-                        authService.resendVerification(request.get("email"))
-                )
+                ApiResponseDto.success(message, null)
         );
     }
 
@@ -98,11 +86,10 @@ public class AuthController {
     //LOGIN
     @PostMapping("/login")
     public ResponseEntity<ApiResponseDto<AuthResponse>> login(@Valid @RequestBody LoginRequest request) {
+        AuthResponse data = authService.login(request);
+
         return ResponseEntity.ok(
-                ApiResponseDto.success(
-                        "Login exitoso",
-                        authService.login(request)
-                )
+                ApiResponseDto.success("Login exitoso", data)
         );
     }
 
@@ -112,11 +99,10 @@ public class AuthController {
 
         String token = header.replace("Bearer ", "");
 
+        AuthResponse data = authService.getUser(token);
+
         return ResponseEntity.ok(
-                ApiResponseDto.success(
-                        "Usuario obtenido",
-                        authService.getUser(token)
-                )
+                ApiResponseDto.success("Usuario obtenido", data)
         );
     }
 
@@ -124,41 +110,40 @@ public class AuthController {
     @PostMapping("/admin/register")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponseDto<String>> registerAdmin(@RequestBody RegisterRequest request) {
+        String message = authService.registerAdmin(request);
+
         return ResponseEntity.ok(
-                ApiResponseDto.success(
-                        authService.registerAdmin(request)
-                )
+                ApiResponseDto.success(message, null)
         );
     }
 
     // FORGOT PASSWORD
     @PostMapping("/forgot-password")
     public ResponseEntity<ApiResponseDto<String>> forgotPassword(@RequestBody ForgotPasswordRequest request) {
+        String message = authService.forgotPassword(request);
+
         return ResponseEntity.ok(
-                ApiResponseDto.success(
-                        authService.forgotPassword(request)
-                )
+                ApiResponseDto.success(message, null)
         );
     }
 
     // RESET PASSWORD
     @PostMapping("/reset-password")
     public ResponseEntity<ApiResponseDto<String>> resetPassword(@RequestBody ResetPasswordRequest request) {
+        String message = authService.resetPassword(request);
+
         return ResponseEntity.ok(
-                ApiResponseDto.success(
-                        authService.resetPassword(request)
-                )
+                ApiResponseDto.success(message, null)
         );
     }
 
     //GOOGLE AUTH
     @PostMapping("/google")
     public ResponseEntity<ApiResponseDto<AuthResponse>> googleAuth(@RequestBody GoogleAuthRequest request){
+        AuthResponse data = authService.googleAuth(request);
+
         return ResponseEntity.ok(
-                ApiResponseDto.success(
-                        "Login con Google exitoso",
-                        authService.googleAuth(request)
-                )
+                ApiResponseDto.success("Login con Google exitoso", data)
         );
     }
 

--- a/src/main/java/com/coworking/auth/controller/AuthController.java
+++ b/src/main/java/com/coworking/auth/controller/AuthController.java
@@ -1,19 +1,17 @@
 package com.coworking.auth.controller;
 import com.coworking.auth.dto.*;
 import com.coworking.auth.model.VerificationToken;
-import com.coworking.auth.repository.PasswordResetTokenRepository;
 import com.coworking.auth.repository.VerificationTokenRepository;
 import com.coworking.auth.service.AuthService;
+import com.coworking.dto.common.ApiResponseDto;
 import com.coworking.exception.NotFoundException;
-import com.coworking.security.JwtUtil;
 import com.coworking.role.model.Role;
+import com.coworking.security.JwtUtil;
 import com.coworking.user.model.User;
 import com.coworking.role.repository.RoleRepository;
 import com.coworking.user.repository.UserRepository;
 
 import com.coworking.email.service.EmailService;
-import com.coworking.auth.service.GoogleAuthService;
-import com.coworking.auth.service.PasswordResetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,8 +20,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.BadRequestException;
-import org.springframework.http.HttpStatus;
+import com.coworking.exception.BadRequestException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -48,20 +45,14 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class AuthController {
 
-    /*private final AuthenticationManager authenticationManager;
+    private final AuthService authService;
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     private final PasswordEncoder passwordEncoder;
     private final VerificationTokenRepository tokenRepository;
     private final EmailService emailService;
-    private final PasswordResetTokenRepository resetTokenRepository;
-    private final PasswordResetService passwordResetService;
-    private final GoogleAuthService googleAuthService;
-    private final JwtUtil jwtUtil;*/
-
-    private final AuthService authService;
-
-
+    private  final JwtUtil jwtUtil;
+    private final AuthenticationManager authenticationManager;
     //REGISTER
     @Operation(
             summary = "Registrar usuarios",
@@ -72,9 +63,9 @@ public class AuthController {
             }
     )
     @PostMapping("/register")
-    public ResponseEntity<?> register(@RequestBody RegisterRequest request){
+    public ResponseEntity<ApiResponseDto<Void>> register(@Valid @RequestBody RegisterRequest request) {
         return ResponseEntity.ok(
-                Map.of("message", authService.register(request))
+                ApiResponseDto.success(authService.register(request))
         );
     }
     //VERIFY EMAIL
@@ -86,12 +77,13 @@ public class AuthController {
 
     //REENVIAR CORREO DE VERIFICACION
     @PostMapping("/resend-verification")
-    public ResponseEntity<?> resendVerification(@RequestBody Map<String, String> request){
+    public ResponseEntity<ApiResponseDto<String>> resendVerification(@RequestBody Map<String, String> request) {
         return ResponseEntity.ok(
-                Map.of("message", authService.resendVerification(request.get("email")))
+                ApiResponseDto.success(
+                        authService.resendVerification(request.get("email"))
+                )
         );
     }
-
 
     //LOGIN
     @Operation(
@@ -105,45 +97,69 @@ public class AuthController {
     )
     //LOGIN
     @PostMapping("/login")
-    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request){
-        return ResponseEntity.ok(authService.login(request));
+    public ResponseEntity<ApiResponseDto<AuthResponse>> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(
+                ApiResponseDto.success(
+                        "Login exitoso",
+                        authService.login(request)
+                )
+        );
     }
+
     // USER
     @GetMapping("/user")
-    public ResponseEntity<AuthResponse> getUser(@RequestHeader("Authorization") String header){
+    public ResponseEntity<ApiResponseDto<AuthResponse>> getUser(@RequestHeader("Authorization") String header){
+
         String token = header.replace("Bearer ", "");
-        return ResponseEntity.ok(authService.getUser(token));
+
+        return ResponseEntity.ok(
+                ApiResponseDto.success(
+                        "Usuario obtenido",
+                        authService.getUser(token)
+                )
+        );
     }
 
     // ADMIN
     @PostMapping("/admin/register")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<?> registerAdmin(@RequestBody RegisterRequest request){
+    public ResponseEntity<ApiResponseDto<String>> registerAdmin(@RequestBody RegisterRequest request) {
         return ResponseEntity.ok(
-                Map.of("message", authService.registerAdmin(request))
+                ApiResponseDto.success(
+                        authService.registerAdmin(request)
+                )
         );
     }
 
     // FORGOT PASSWORD
     @PostMapping("/forgot-password")
-    public ResponseEntity<?> forgotPassword(@RequestBody ForgotPasswordRequest request) throws BadRequestException {
+    public ResponseEntity<ApiResponseDto<String>> forgotPassword(@RequestBody ForgotPasswordRequest request) {
         return ResponseEntity.ok(
-                Map.of("message", authService.forgotPassword(request))
+                ApiResponseDto.success(
+                        authService.forgotPassword(request)
+                )
         );
     }
 
     // RESET PASSWORD
     @PostMapping("/reset-password")
-    public ResponseEntity<?> resetPassword(@RequestBody ResetPasswordRequest request) throws BadRequestException {
+    public ResponseEntity<ApiResponseDto<String>> resetPassword(@RequestBody ResetPasswordRequest request) {
         return ResponseEntity.ok(
-                Map.of("message", authService.resetPassword(request))
+                ApiResponseDto.success(
+                        authService.resetPassword(request)
+                )
         );
     }
 
     //GOOGLE AUTH
     @PostMapping("/google")
-    public ResponseEntity<AuthResponse> googleAuth(@RequestBody GoogleAuthRequest request){
-        return ResponseEntity.ok(authService.googleAuth(request));
+    public ResponseEntity<ApiResponseDto<AuthResponse>> googleAuth(@RequestBody GoogleAuthRequest request){
+        return ResponseEntity.ok(
+                ApiResponseDto.success(
+                        "Login con Google exitoso",
+                        authService.googleAuth(request)
+                )
+        );
     }
 
 }

--- a/src/main/java/com/coworking/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/coworking/auth/dto/RegisterRequest.java
@@ -3,9 +3,12 @@ package com.coworking.auth.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "Request para registrar un usuario")
 public record RegisterRequest(
+
         String username,
 
         @NotBlank(message = "Email es obligatorio")

--- a/src/main/java/com/coworking/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/coworking/auth/dto/RegisterRequest.java
@@ -12,6 +12,11 @@ public record RegisterRequest(
         @Email(message = "Formato de email inválido")
         String email,
 
+        @Size(min = 8, message = "La contraseña debe tener al menos 8 caracteres")
+        @Pattern(
+                regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&]).+$",
+                message = "La contraseña debe tener mayúsculas, minúsculas, número y símbolo"
+        )
         String password,
 
         Boolean termsAccepted

--- a/src/main/java/com/coworking/auth/service/AuthService.java
+++ b/src/main/java/com/coworking/auth/service/AuthService.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.coworking.exception.BadRequestException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -220,7 +221,7 @@ public class AuthService {
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                     FORGOT PASSWORD
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
-    public String forgotPassword(ForgotPasswordRequest request) throws org.apache.coyote.BadRequestException {
+    public String forgotPassword(ForgotPasswordRequest request) {
 
         passwordResetService.sendResetLink(request.getEmail());
 
@@ -230,7 +231,7 @@ public class AuthService {
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                     RESET PASSWORD
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
-    public String resetPassword(ResetPasswordRequest request) throws org.apache.coyote.BadRequestException {
+    public String resetPassword(ResetPasswordRequest request) {
 
         passwordResetService.resetPassword(request);
 

--- a/src/main/java/com/coworking/auth/service/PasswordResetService.java
+++ b/src/main/java/com/coworking/auth/service/PasswordResetService.java
@@ -3,11 +3,11 @@ package com.coworking.auth.service;
 import com.coworking.auth.dto.ResetPasswordRequest;
 import com.coworking.email.service.EmailService;
 import com.coworking.auth.model.PasswordResetToken;
+import com.coworking.exception.BadRequestException;
 import com.coworking.user.model.User;
 import com.coworking.auth.repository.PasswordResetTokenRepository;
 import com.coworking.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.BadRequestException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/coworking/dto/common/ApiResponseDto.java
+++ b/src/main/java/com/coworking/dto/common/ApiResponseDto.java
@@ -1,0 +1,35 @@
+package com.coworking.dto.common;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "Respuesta estándar de la API")
+public class ApiResponseDto<T> {
+
+    @Schema(description = "Indica si la operación fue exitosa")
+    private boolean success;
+
+    @Schema(description = "Mensaje descriptivo")
+    private String message;
+
+    @Schema(description = "Datos de la respuesta")
+    private T data;
+
+    // Metodos helper
+    public static <T> ApiResponseDto<T> success(String message, T data){
+        return new ApiResponseDto<>(true, message, data);
+    }
+
+    public static <T> ApiResponseDto<T> success(String message){
+        return new ApiResponseDto<>(true, message, null);
+    }
+
+    public static <T> ApiResponseDto<T> error(String message){
+        return new ApiResponseDto<>(false, message, null);
+    }
+}

--- a/src/main/java/com/coworking/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/coworking/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.coworking.exception;
 
+import com.coworking.dto.common.ApiResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.*;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -19,12 +21,18 @@ public class GlobalExceptionHandler {
     public ResponseEntity<?> handleValidation(MethodArgumentNotValidException ex,
                                               HttpServletRequest request){
 
-        Map<String, String> errors = ex.getBindingResult()
+        Map<String, List<String>> errors = ex.getBindingResult()
                 .getFieldErrors()
                 .stream()
-                .collect(Collectors.toMap(
+                .collect(Collectors.groupingBy(
                         FieldError::getField,
-                        DefaultMessageSourceResolvable::getDefaultMessage
+                        Collectors.mapping(
+                                error -> {
+                                    String msg = error.getDefaultMessage();
+                                    return msg != null ? msg : "Valor inválido";
+                                },
+                                Collectors.toList()
+                        )
                 ));
 
         return ResponseEntity.badRequest().body(errors);
@@ -32,16 +40,18 @@ public class GlobalExceptionHandler {
 
     // BAD REQUEST
     @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<ApiError> handleBadRequest(BadRequestException ex,
-                                                     HttpServletRequest request){
-        return buildError(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    public ResponseEntity<ApiResponseDto<Void>> handleBadRequest(BadRequestException ex, HttpServletRequest request){
+        return ResponseEntity.badRequest().body(
+                ApiResponseDto.error(ex.getMessage())
+        );
     }
 
     // NOT FOUND
     @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<ApiError> handleNotFound(NotFoundException ex,
-                                                   HttpServletRequest request){
-        return buildError(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+    public ResponseEntity<ApiResponseDto<Void>> handleNotFound(NotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                ApiResponseDto.error(ex.getMessage())
+        );
     }
 
     // CONFLICT (reservas)

--- a/src/main/java/com/coworking/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/coworking/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.coworking.dto.common.ApiResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.*;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
@@ -43,6 +44,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponseDto<Void>> handleBadRequest(BadRequestException ex, HttpServletRequest request){
         return ResponseEntity.badRequest().body(
                 ApiResponseDto.error(ex.getMessage())
+        );
+    }
+
+
+    //BAD CREDENTIAL
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleBadCredentials(BadCredentialsException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                ApiResponseDto.error("Credenciales incorrectas")
         );
     }
 

--- a/src/test/java/com/coworking/resources/controller/AuthControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/AuthControllerTest.java
@@ -211,5 +211,21 @@ public class AuthControllerTest {
                 .andExpect(jsonPath("$.message").exists());
     }
 
+    @Test
+    void shouldSendResetLink() throws Exception {
+
+        ForgotPasswordRequest request = new ForgotPasswordRequest();
+        request.setEmail("test@mail.com");
+
+        when(authService.forgotPassword(any()))
+                .thenReturn("Se enviará un enlace de recuperación a su correo registrado");
+
+        mockMvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message")
+                        .value("Se enviará un enlace de recuperación a su correo registrado"));
+    }
 
 }

--- a/src/test/java/com/coworking/resources/controller/AuthControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/AuthControllerTest.java
@@ -1,41 +1,38 @@
 package com.coworking.resources.controller;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
+import com.coworking.auth.dto.AuthResponse;
+import com.coworking.auth.dto.ForgotPasswordRequest;
 import com.coworking.auth.repository.PasswordResetTokenRepository;
 import com.coworking.auth.repository.VerificationTokenRepository;
+import com.coworking.auth.service.AuthService;
 import com.coworking.email.service.EmailService;
 import com.coworking.auth.service.GoogleAuthService;
 import com.coworking.auth.service.PasswordResetService;
+import com.coworking.exception.BadRequestException;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.coworking.auth.controller.AuthController;
 import com.coworking.auth.dto.LoginRequest;
 import com.coworking.auth.dto.RegisterRequest;
-import com.coworking.role.model.Role;
-import com.coworking.user.model.User;
 import com.coworking.role.repository.RoleRepository;
 import com.coworking.user.repository.UserRepository;
 import com.coworking.security.JwtUtil;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -77,10 +74,14 @@ public class AuthControllerTest {
     @MockitoBean
     private GoogleAuthService googleAuthService;
 
+    @MockitoBean
+    private AuthService authService;
+
     // REGISTER TESTS
 
     @Test
     void shouldRegisterSuccessfully() throws Exception {
+
         RegisterRequest request = new RegisterRequest(
                 "userTest",
                 "test@mail.com",
@@ -88,20 +89,8 @@ public class AuthControllerTest {
                 true
         );
 
-        Role role = new Role();
-        role.setName("ROLE_USER");
-
-        Mockito.when(userRepository.findByEmail("test@mail.com"))
-                .thenReturn(Optional.empty());
-
-        Mockito.when(roleRepository.findByName("ROLE_USER"))
-                .thenReturn(Optional.of(role));
-
-        Mockito.when(passwordEncoder.encode("Aa123456!"))
-                .thenReturn("encodedPass");
-
-        Mockito.when(jwtUtil.generateToken(any(UserDetails.class), eq("userTest"), anyBoolean()))
-                .thenReturn("fake-jwt");
+        when(authService.register(any()))
+                .thenReturn("Registro exitoso. Revisa tu correo para activar tu cuenta.");
 
         mockMvc.perform(post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -113,22 +102,43 @@ public class AuthControllerTest {
 
     @Test
     void shouldReturn400WhenEmailAlreadyExists() throws Exception {
+
         RegisterRequest request = new RegisterRequest(
-                "other",
-                "duplicate@mail.com",
-                "12345678",
+                "userTest",
+                "test@mail.com",
+                "Aa123456!",
                 true
         );
 
-        Mockito.when(userRepository.findByEmail("duplicate@mail.com"))
-                .thenReturn(Optional.of(new User()));
+        when(authService.register(any()))
+                .thenThrow(new BadRequestException("Correo ya está registrado"));
 
         mockMvc.perform(post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.field").value("email"))
-                .andExpect(jsonPath("$.message").value("Correo ya está registrado"));
+                .andExpect(jsonPath("$.message")
+                        .value("Correo ya está registrado"));
+    }
+
+    @Test
+    void shouldReturn400WhenEmailNotVerified() throws Exception {
+
+        LoginRequest request = new LoginRequest(
+                "test@mail.com",
+                "Aa123456!",
+                false
+        );
+
+        when(authService.login(any()))
+                .thenThrow(new BadRequestException("EMAIL_NOT_VERIFIED"));
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message")
+                        .value("EMAIL_NOT_VERIFIED"));
     }
 
     @Test
@@ -147,68 +157,64 @@ public class AuthControllerTest {
     }
 
     // LOGIN TESTS
-
     @Test
     void shouldLoginSuccessfully() throws Exception {
-        LoginRequest request = new LoginRequest("login@mail.com", "123456", false);
 
-        User user = new User();
-        user.setUsername("loginUser");
-        user.setEmail("login@mail.com");
-        user.setEnabled(true);
-        user.setRoles(Set.of(new Role("ROLE_USER")));
+        LoginRequest request = new LoginRequest(
+                "test@mail.com",
+                "Aa123456!",
+                false
+        );
 
-        Authentication authMock = Mockito.mock(Authentication.class);
+        AuthResponse response = new AuthResponse("token", "userTest", "ROLE_USER");
 
-        Mockito.when(authenticationManager.authenticate(any()))
-                .thenReturn(authMock);
-
-        Mockito.when(userRepository.findByEmail("login@mail.com"))
-                .thenReturn(Optional.of(user));
-
-        Mockito.when(jwtUtil.generateToken(any(UserDetails.class), eq("loginUser"), eq(false)))
-                .thenReturn("jwt-login");
-
-        UserDetails springUser =
-                new org.springframework.security.core.userdetails.User(
-                        "login@mail.com",
-                        "encoded",
-                        List.of()
-                );
-
-        Mockito.when(authMock.getPrincipal()).thenReturn(springUser);
+        when(authService.login(any()))
+                .thenReturn(response);
 
         mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Login exitoso"))
+                .andExpect(jsonPath("$.data.token").value("token"));
     }
 
 
     @Test
     void shouldReturn401WhenBadCredentials() throws Exception {
-        LoginRequest request = new LoginRequest("wrong@mail.com", "fail", false);
 
-        Mockito.when(authenticationManager.authenticate(any()))
-                .thenThrow(new BadCredentialsException("Bad creds"));
+        LoginRequest request = new LoginRequest(
+                "test@mail.com",
+                "wrongpass",
+                false
+        );
+
+        when(authService.login(any()))
+                .thenThrow(new BadCredentialsException("Credenciales incorrectas"));
 
         mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.message").value("Correo o contraseña incorrectos"));
+                .andExpect(jsonPath("$.message")
+                        .value("Credenciales incorrectas"));
     }
 
     @Test
     void shouldReturn400WhenPasswordIsWeak() throws Exception {
-        RegisterRequest request = new RegisterRequest("User", "email@test.com", "12345", true);
+
+        RegisterRequest request = new RegisterRequest(
+                "User",
+                "email@test.com",
+                "12345",
+                true
+        );
 
         mockMvc.perform(post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.field").value("password"))
-                .andExpect(jsonPath("$.message").exists());
+                .andExpect(jsonPath("$.password").exists());
     }
 
     @Test

--- a/src/test/java/com/coworking/resources/service/AuthServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/AuthServiceTest.java
@@ -1,0 +1,194 @@
+package com.coworking.resources.service;
+
+import com.coworking.auth.dto.ForgotPasswordRequest;
+import com.coworking.auth.dto.LoginRequest;
+import com.coworking.auth.dto.RegisterRequest;
+import com.coworking.auth.repository.PasswordResetTokenRepository;
+import com.coworking.auth.repository.VerificationTokenRepository;
+import com.coworking.auth.service.AuthService;
+import com.coworking.auth.service.PasswordResetService;
+import com.coworking.email.service.EmailService;
+import com.coworking.exception.BadRequestException;
+import com.coworking.exception.NotFoundException;
+import com.coworking.role.model.Role;
+import com.coworking.role.repository.RoleRepository;
+import com.coworking.security.JwtUtil;
+import com.coworking.user.model.User;
+import com.coworking.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private RoleRepository roleRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private PasswordResetService passwordResetService;
+    @Mock private VerificationTokenRepository verificationTokenRepository;
+    @Mock private EmailService emailService;
+    @Mock private AuthenticationManager authenticationManager;
+    @Mock private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private AuthService authService;
+
+    // REGISTER
+
+    @Test
+    void shouldRegisterSuccessfully() {
+        RegisterRequest request = new RegisterRequest(
+                "user",
+                "test@mail.com",
+                "Aa123456!",
+                true
+        );
+
+        Role role = new Role();
+        role.setName("ROLE_USER");
+
+        when(userRepository.findByEmail("test@mail.com"))
+                .thenReturn(Optional.empty());
+
+        when(roleRepository.findByName("ROLE_USER"))
+                .thenReturn(Optional.of(role));
+
+        when(passwordEncoder.encode(any()))
+                .thenReturn("encoded");
+
+        String result = authService.register(request);
+
+        assertEquals("Registro exitoso. Revisa tu correo para activar tu cuenta.", result);
+        verify(userRepository).save(any(User.class));
+    }
+    //LOGIN
+    @Test
+    void shouldThrowWhenBadCredentials() {
+
+        LoginRequest request = new LoginRequest(
+                "test@mail.com",
+                "wrongpass",
+                false
+        );
+
+        User user = new User();
+        user.setEnabled(true);
+
+        when(userRepository.findByEmail(any()))
+                .thenReturn(Optional.of(user));
+
+        when(authenticationManager.authenticate(any()))
+                .thenThrow(new BadCredentialsException("Credenciales incorrectas"));
+
+        assertThrows(BadCredentialsException.class,
+                () -> authService.login(request));
+    }
+    //ROLE
+    @Test
+    void shouldThrowWhenRoleNotFound() {
+
+        RegisterRequest request = new RegisterRequest(
+                "user",
+                "test@mail.com",
+                "Aa123456!",
+                true
+        );
+
+        when(userRepository.findByEmail(any()))
+                .thenReturn(Optional.empty());
+
+        when(roleRepository.findByName("ROLE_USER"))
+                .thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class,
+                () -> authService.register(request));
+    }
+
+    //EMAIL
+    @Test
+    void shouldThrowWhenEmailNotVerified() {
+
+        LoginRequest request = new LoginRequest(
+                "test@mail.com",
+                "Aa123456!",
+                false
+        );
+
+        User user = new User();
+        user.setEnabled(false);
+
+        when(userRepository.findByEmail(any()))
+                .thenReturn(Optional.of(user));
+
+        assertThrows(BadRequestException.class,
+                () -> authService.login(request));
+    }
+    @Test
+    void shouldThrowWhenEmailExists() {
+        RegisterRequest request = new RegisterRequest(
+                "user",
+                "test@mail.com",
+                "Aa123456!",
+                true
+        );
+
+        when(userRepository.findByEmail("test@mail.com"))
+                .thenReturn(Optional.of(new User()));
+
+        assertThrows(BadRequestException.class,
+                () -> authService.register(request));
+    }
+
+    // PASSWORD
+
+    @Test
+    void shouldCallPasswordResetService() {
+        ForgotPasswordRequest request = new ForgotPasswordRequest();
+        request.setEmail("test@mail.com");
+
+        String result = authService.forgotPassword(request);
+
+        verify(passwordResetService)
+                .sendResetLink("test@mail.com");
+
+        assertEquals("Se enviará un enlace de recuperación a su correo registrado", result);
+    }
+
+    @Test
+    void shouldThrowWhenPasswordIsWeak() {
+
+        RegisterRequest request = new RegisterRequest(
+                "user",
+                "test@mail.com",
+                "12345",
+                true
+        );
+
+        assertThrows(BadRequestException.class,
+                () -> authService.register(request));
+    }
+
+    //VALIDACIONES
+    @Test
+    void shouldThrowWhenTermsNotAccepted() {
+
+        RegisterRequest request = new RegisterRequest(
+                "user",
+                "test@mail.com",
+                "Aa123456!",
+                false
+        );
+
+        assertThrows(BadRequestException.class,
+                () -> authService.register(request));
+    }
+}


### PR DESCRIPTION
En este PR se realizaron mejoras en el modulo de authenticacion.

### 1. Respuesta del endpoint register
- Se corrigió la forma en que se construye la respuesta para evitar valores nulos en el campo `message`.
- Ahora el mensaje se obtiene previamente desde el servicio antes de construir el `ApiResponseDto`.

### 2. Manejo de excepciones
- Se agregó manejo de `BadCredentialsException` en `GlobalExceptionHandler`.
- Se retorna correctamente HTTP 401 con un mensaje claro para credenciales inválidas.

### 3. Validaciones
- Se fortalecieron las validaciones del campo `password` en `RegisterRequest`:
    - Longitud mínima de 8 caracteres
    - Requisitos de complejidad (mayúsculas, minúsculas, número y símbolo)

### 4. Testing
- Se separaron los tests de lógica en `AuthServiceTest`.
- Se mejoraron y adaptaron los tests del controller (`AuthControllerTest`) al nuevo formato de respuesta.
- Se corrigieron fallos relacionados con validaciones y manejo de errores.