### PR TITLE
Feat/stripe webhook

### DIFF
--- a/src/main/java/com/coworking/config/SecurityConfig.java
+++ b/src/main/java/com/coworking/config/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
                         .hasAnyRole("USER","ADMIN")
                         .requestMatchers("/api/hello").permitAll()
                         .requestMatchers("/uploads/**").permitAll()
+                        .requestMatchers("/api/payments/webhook").permitAll()
                         .anyRequest().authenticated()
                 )
                 .authenticationProvider(authenticationProvider)

--- a/src/main/java/com/coworking/payment/controller/stripe/StripeWebhookController.java
+++ b/src/main/java/com/coworking/payment/controller/stripe/StripeWebhookController.java
@@ -34,7 +34,7 @@ public class StripeWebhookController {
     public ResponseEntity<String> handleStripeWebhook(HttpServletRequest request){
         String payload;
         try {
-            payload = request.getReader().lines().collect(Collectors.joining());
+            payload = new String(request.getInputStream().readAllBytes());
         } catch (IOException e) {
             return ResponseEntity.badRequest().body("Invalid payload");
         }

--- a/src/main/java/com/coworking/payment/controller/stripe/StripeWebhookController.java
+++ b/src/main/java/com/coworking/payment/controller/stripe/StripeWebhookController.java
@@ -1,0 +1,106 @@
+package com.coworking.payment.controller.stripe;
+
+
+import com.coworking.reservation.service.ReservationService;
+import com.stripe.model.Event;
+import com.stripe.model.EventDataObjectDeserializer;
+import com.stripe.model.PaymentIntent;
+import com.stripe.model.StripeObject;
+import com.stripe.model.checkout.Session;
+import com.stripe.net.Webhook;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+public class StripeWebhookController {
+    @Value("${stripe.webhook-secret}")
+    private String webhookSecret;
+
+    private final ReservationService reservationService;
+
+    @PostMapping("/webhook")
+    public ResponseEntity<String> handleStripeWebhook(HttpServletRequest request){
+        String payload;
+        try {
+            payload = request.getReader().lines().collect(Collectors.joining());
+        } catch (IOException e) {
+            return ResponseEntity.badRequest().body("Invalid payload");
+        }
+
+        String sigHeader = request.getHeader("Stripe-Signature");
+
+        Event event;
+
+        try {
+            event = Webhook.constructEvent(payload, sigHeader, webhookSecret);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Fallo la verificacion");
+        }
+
+        System.out.println("Webhook recibido: " + event.getType());
+
+        //MANEJO DE EVENTOS
+
+        switch (event.getType()){
+           /* case "checkout.session.completed":
+                handleCheckoutSessionCompleted(event);
+                break;
+            */
+            case "payment_intent.succeeded":
+                handlePaymentIntentSucceeded(event);
+                break;
+
+            default:
+                System.out.println("Unhandled event: " + event.getType());
+        }
+
+        return ResponseEntity.ok("Recibido");
+    }
+
+    private void handlePaymentIntentSucceeded(Event event) {
+        EventDataObjectDeserializer dataObjectDeserializer = event.getDataObjectDeserializer();
+        Optional<StripeObject> object = dataObjectDeserializer.getObject();
+
+        if (object.isPresent()) {
+            PaymentIntent paymentIntent =
+                    (PaymentIntent) object.get();
+
+            String reservationId = paymentIntent.getMetadata().get("reservationId");
+
+            if (reservationId != null) {
+                reservationService.markAsPaid(Long.parseLong(reservationId));
+            }
+        }
+
+    }
+
+    private void handleCheckoutSessionCompleted(Event event) {
+        EventDataObjectDeserializer dataObjectDeserializer = event.getDataObjectDeserializer();
+
+        Optional<StripeObject> object = dataObjectDeserializer.getObject();
+
+        if (object.isPresent()){
+            Session session = (Session) object.get();
+            String reservationId = session.getMetadata().get("reservationId");
+
+            if (reservationId != null){
+                reservationService.markAsPaid(Long.parseLong(reservationId));
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/com/coworking/payment/controller/stripe/StripeWebhookController.java
+++ b/src/main/java/com/coworking/payment/controller/stripe/StripeWebhookController.java
@@ -1,7 +1,7 @@
 package com.coworking.payment.controller.stripe;
 
-
 import com.coworking.reservation.service.ReservationService;
+import com.stripe.exception.EventDataObjectDeserializationException;
 import com.stripe.model.Event;
 import com.stripe.model.EventDataObjectDeserializer;
 import com.stripe.model.PaymentIntent;
@@ -10,12 +10,12 @@ import com.stripe.model.checkout.Session;
 import com.stripe.net.Webhook;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -25,82 +25,87 @@ import java.util.stream.Collectors;
 @RequestMapping("/api/payments")
 @RequiredArgsConstructor
 public class StripeWebhookController {
+
+    private static final Logger log = LoggerFactory.getLogger(StripeWebhookController.class);
+
     @Value("${stripe.webhook-secret}")
     private String webhookSecret;
 
     private final ReservationService reservationService;
 
     @PostMapping("/webhook")
-    public ResponseEntity<String> handleStripeWebhook(HttpServletRequest request){
+    public ResponseEntity<String> handleStripeWebhook(HttpServletRequest request) {
         String payload;
         try {
             payload = new String(request.getInputStream().readAllBytes());
         } catch (IOException e) {
+            log.error("Error leyendo payload", e);
             return ResponseEntity.badRequest().body("Invalid payload");
         }
 
         String sigHeader = request.getHeader("Stripe-Signature");
 
         Event event;
-
         try {
+            log.info("Webhook secret usado: {}", webhookSecret);
             event = Webhook.constructEvent(payload, sigHeader, webhookSecret);
-
         } catch (Exception e) {
+            log.error("Error validando firma de Stripe", e);
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Fallo la verificacion");
         }
 
-        System.out.println("Webhook recibido: " + event.getType());
+        log.info("Webhook recibido: {}", event.getType());
 
-        //MANEJO DE EVENTOS
+        try {
+            switch (event.getType()) {
+                case "payment_intent.succeeded":
+                    handlePaymentIntentSucceeded(event);
+                    break;
 
-        switch (event.getType()){
-           /* case "checkout.session.completed":
-                handleCheckoutSessionCompleted(event);
-                break;
-            */
-            case "payment_intent.succeeded":
-                handlePaymentIntentSucceeded(event);
-                break;
+                /*
+                case "checkout.session.completed":
+                    handleCheckoutSessionCompleted(event);
+                    break;
+                */
 
-            default:
-                System.out.println("Unhandled event: " + event.getType());
+                default:
+                    log.warn("Evento no manejado: {}", event.getType());
+            }
+        } catch (Exception e) {
+            log.error("Error procesando evento de Stripe", e);
         }
 
         return ResponseEntity.ok("Recibido");
     }
 
-    private void handlePaymentIntentSucceeded(Event event) {
-        EventDataObjectDeserializer dataObjectDeserializer = event.getDataObjectDeserializer();
-        Optional<StripeObject> object = dataObjectDeserializer.getObject();
+    private void handlePaymentIntentSucceeded(Event event) throws EventDataObjectDeserializationException {
 
-        if (object.isPresent()) {
-            PaymentIntent paymentIntent =
-                    (PaymentIntent) object.get();
-
-            String reservationId = paymentIntent.getMetadata().get("reservationId");
-
-            if (reservationId != null) {
-                reservationService.markAsPaid(Long.parseLong(reservationId));
-            }
-        }
-
-    }
-
-    private void handleCheckoutSessionCompleted(Event event) {
         EventDataObjectDeserializer dataObjectDeserializer = event.getDataObjectDeserializer();
 
-        Optional<StripeObject> object = dataObjectDeserializer.getObject();
+        StripeObject stripeObject = dataObjectDeserializer.getObject().orElse(null);
 
-        if (object.isPresent()){
-            Session session = (Session) object.get();
-            String reservationId = session.getMetadata().get("reservationId");
+        if (stripeObject == null) {
+            stripeObject = dataObjectDeserializer.deserializeUnsafe();
+        }
 
-            if (reservationId != null){
-                reservationService.markAsPaid(Long.parseLong(reservationId));
-            }
+        PaymentIntent paymentIntent = (PaymentIntent) stripeObject;
+
+        if (paymentIntent.getMetadata() == null ||
+                !paymentIntent.getMetadata().containsKey("reservationId")) {
+
+            log.warn("PaymentIntent sin reservationId en metadata");
+            return;
+        }
+
+        String reservationId = paymentIntent.getMetadata().get("reservationId");
+
+        try {
+            Long id = Long.parseLong(reservationId);
+            reservationService.markAsPaid(id);
+            log.info("Reserva {} marcada como PAID", id);
+
+        } catch (NumberFormatException e) {
+            log.error("reservationId inválido: {}", reservationId, e);
         }
     }
-
-
 }

--- a/src/main/java/com/coworking/payment/service/StripePaymentService.java
+++ b/src/main/java/com/coworking/payment/service/StripePaymentService.java
@@ -1,5 +1,6 @@
 package com.coworking.payment.service;
 
+import com.coworking.exception.NotFoundException;
 import com.coworking.reservation.model.Reservation;
 import com.coworking.reservation.model.ReservationStatus;
 import com.coworking.reservation.repository.ReservationRepository;
@@ -18,7 +19,7 @@ public class StripePaymentService implements PaymentService {
     public String createPaymentIntent(Long reservationId) {
 
         Reservation reservation = reservationRepository.findById(reservationId)
-                .orElseThrow(() -> new RuntimeException("Reserva no encontrada"));
+                .orElseThrow(() -> new NotFoundException("Reserva no encontrada"));
 
         //Validar estado
         if (reservation.getStatus() != ReservationStatus.PENDING){

--- a/src/main/java/com/coworking/payment/service/stripe/StripeClientImpl.java
+++ b/src/main/java/com/coworking/payment/service/stripe/StripeClientImpl.java
@@ -19,10 +19,6 @@ public class StripeClientImpl implements StripeClient {
 
         try {
 
-            if (price == null || price.compareTo(BigDecimal.ZERO) <= 0) {
-                throw new RuntimeException("Monto inválido para pago");
-            }
-
             long amount = price.multiply(BigDecimal.valueOf(100)).longValue();
 
             PaymentIntentCreateParams params =

--- a/src/main/java/com/coworking/reservation/service/ReservationService.java
+++ b/src/main/java/com/coworking/reservation/service/ReservationService.java
@@ -187,4 +187,18 @@ public class ReservationService {
                 ))
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public void markAsPaid(long reservationId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new NotFoundException("Reservacion no encontrada"));
+
+        if (reservation.getStatus() == ReservationStatus.PAID) {
+            return; //evitar procesar
+        }
+
+        reservation.setStatus(ReservationStatus.PAID);
+
+        reservationRepository.save(reservation);
+    }
 }

--- a/src/test/java/com/coworking/resources/service/payment/StripePaymentServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/payment/StripePaymentServiceTest.java
@@ -1,5 +1,6 @@
 package com.coworking.resources.service.payment;
 
+import com.coworking.exception.NotFoundException;
 import com.coworking.payment.service.PaymentService;
 import com.coworking.payment.service.StripePaymentService;
 import com.coworking.payment.service.stripe.StripeClient;
@@ -47,5 +48,49 @@ class StripePaymentServiceTest {
         String clientSecret = paymentService.createPaymentIntent(1L);
 
         assertNotNull(clientSecret);
+
+        //verification
+        Mockito.verify(stripeClient, Mockito.times(1))
+                .createPaymentIntent(BigDecimal.valueOf(10), 1L);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenReservationNotFound() {
+
+        // Arrange
+        Mockito.when(reservationRepository.findById(1L))
+                .thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(NotFoundException.class, () -> {
+            paymentService.createPaymentIntent(1L);
+        });
+
+        // stripe nunca debe llamarse
+        Mockito.verifyNoInteractions(stripeClient);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenStripeFails() {
+
+        // Arrange
+        Reservation reservation = new Reservation();
+        reservation.setId(1L);
+        reservation.setPrice(BigDecimal.valueOf(10));
+
+        Mockito.when(reservationRepository.findById(1L))
+                .thenReturn(Optional.of(reservation));
+
+        Mockito.when(stripeClient.createPaymentIntent(Mockito.any(), Mockito.any()))
+                .thenThrow(new RuntimeException("Stripe error"));
+
+        // Act & Assert
+        assertThrows(RuntimeException.class, () -> {
+            paymentService.createPaymentIntent(1L);
+        });
+
+        // verifica si intentó llamar a Stripe
+        Mockito.verify(stripeClient)
+                .createPaymentIntent(BigDecimal.valueOf(10), 1L);
     }
 }

--- a/src/test/java/com/coworking/resources/service/reservation/ReservationServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/reservation/ReservationServiceTest.java
@@ -1,5 +1,6 @@
 package com.coworking.resources.service.reservation;
 
+import com.coworking.exception.NotFoundException;
 import com.coworking.reservation.dto.ReservationRequest;
 import com.coworking.reservation.dto.ReservationResponse;
 import com.coworking.exception.ReservationConflictException;
@@ -239,4 +240,53 @@ class ReservationServiceTest {
 
         verify(reservationRepository).deleteById(1L);
     }
+
+
+    //stripe paid
+
+    @Test
+    void shouldMarkReservationAsPaid() {
+
+        Reservation reservation = new Reservation();
+        reservation.setId(1L);
+        reservation.setStatus(ReservationStatus.PENDING);
+
+        when(reservationRepository.findById(1L))
+                .thenReturn(Optional.of(reservation));
+
+        reservationService.markAsPaid(1L);
+
+        assertEquals(ReservationStatus.PAID, reservation.getStatus());
+
+        verify(reservationRepository).save(reservation);
+    }
+
+    @Test
+    void shouldNotUpdateIfAlreadyPaid() {
+
+        Reservation reservation = new Reservation();
+        reservation.setId(1L);
+        reservation.setStatus(ReservationStatus.PAID);
+
+        when(reservationRepository.findById(1L))
+                .thenReturn(Optional.of(reservation));
+
+        reservationService.markAsPaid(1L);
+
+        assertEquals(ReservationStatus.PAID, reservation.getStatus());
+
+        verify(reservationRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldThrowIfReservationNotFound() {
+
+        when(reservationRepository.findById(1L))
+                .thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class,
+                () -> reservationService.markAsPaid(1L));
+    }
+
+
 }


### PR DESCRIPTION
En este PR se hizo integración de Stripe con webhook, implementa el flujo completo de pagos con Stripe, incluyendo la creación de PaymentIntent, manejo de webhooks y actualización automática del estado de las reservas.

**Pagos con Stripe**

- Se implementa la creación de PaymentIntent
- Se convierte el monto a centavos antes de enviarlo a Stripe
- Se agrega manejo de errores en la integración con Stripe

**Webhook de Stripe**

- Se crea StripeWebhookController
- Endpoint: /api/payments/webhook
- Validación de firma del webhook (Stripe-Signature)
- Manejo del evento:
- payment_intent.succeeded → marca la reserva como PAID

**Lógica de negocio**

- Se agrega método markAsPaid en ReservationService
- Evita reprocesar reservas ya pagadas
- Manejo de errores con NotFoundException

**Tests**

- Tests para StripePaymentService:
- flujo exitoso
- reserva no encontrada
- error de Stripe
- Tests para ReservationService.markAsPaid:
- marca correctamente como PAID
- no actualiza si ya está pagada
- lanza excepción si no existe

