### PR TITLE
feat: agregar endpoint para obtener reservas del usuario autenticado

### DIFF
--- a/src/main/java/com/coworking/reservation/controller/ReservationController.java
+++ b/src/main/java/com/coworking/reservation/controller/ReservationController.java
@@ -8,6 +8,7 @@ import com.coworking.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
@@ -47,6 +48,15 @@ public class ReservationController {
     @Operation(summary = "Listar todas las reservas")
     public List<ReservationResponse> getAll() {
         return reservationService.getAllReservations();
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<List<ReservationResponse>> getMyReservations( Authentication authentication){
+        return ResponseEntity.ok(
+                reservationService.getMyReservations(
+                        authentication.getName()
+                )
+        );
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/coworking/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/coworking/reservation/repository/ReservationRepository.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
+    List<Reservation> findByUserEmailOrderByCreatedAtDesc(String email);
+
     //verificar si se cruzan horarios
     List<Reservation> findByRoomIdAndStartAtLessThanAndEndAtGreaterThan(
             Long roomId,

--- a/src/main/java/com/coworking/reservation/service/ReservationService.java
+++ b/src/main/java/com/coworking/reservation/service/ReservationService.java
@@ -158,12 +158,23 @@ public class ReservationService {
         return dto;
     }
 
+    //Obtener todas las reservaciones
     public List<ReservationResponse> getAllReservations() {
         return reservationRepository.findAll().stream()
                 .map(this::mapToResponse)
                 .collect(Collectors.toList());
     }
 
+    //Obtener mi reserva
+    public List<ReservationResponse> getMyReservations(String email){
+        return reservationRepository
+                .findByUserEmailOrderByCreatedAtDesc(email)
+                .stream()
+                .map(this::mapToResponse)
+                .collect(Collectors.toList());
+    }
+
+    //Eliminar reservacion por id
     public void deleteReservation(Long id) {
         if (!reservationRepository.existsById(id))
             throw new RuntimeException("Reserva no encontrada");

--- a/src/test/java/com/coworking/resources/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/reservation/ReservationControllerTest.java
@@ -1,48 +1,52 @@
 package com.coworking.resources.controller.reservation;
 
-
 import com.coworking.reservation.controller.ReservationController;
 import com.coworking.reservation.dto.ReservationRequest;
 import com.coworking.reservation.dto.ReservationResponse;
-import com.coworking.user.model.User;
-import com.coworking.user.repository.UserRepository;
+import com.coworking.reservation.service.ReservationService;
 import com.coworking.security.JwtAuthenticationFilter;
 import com.coworking.security.JwtUtil;
-import com.coworking.reservation.service.ReservationService;
+import com.coworking.user.model.User;
+import com.coworking.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ReservationController.class)
 @AutoConfigureMockMvc
-public class ReservationControllerTest {
+class ReservationControllerTest {
+
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockitoBean
     private ReservationService reservationService;
 
     @MockitoBean
     private UserRepository userRepository;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -51,12 +55,16 @@ public class ReservationControllerTest {
     private JwtUtil jwtUtil;
 
     @Test
+    @WithMockUser(username = "user@mail.com", roles = "USER")
     void createReservation_shouldReturn200() throws Exception {
 
         ReservationRequest request = new ReservationRequest();
         request.setRoomId(1L);
         request.setStartAt(Instant.parse("2025-10-01T10:00:00Z"));
         request.setEndAt(Instant.parse("2025-10-01T12:00:00Z"));
+
+        ReservationResponse response = new ReservationResponse();
+        response.setId(1L);
 
         User user = new User();
         user.setId(1L);
@@ -65,15 +73,29 @@ public class ReservationControllerTest {
         when(userRepository.findByEmail("user@mail.com"))
                 .thenReturn(Optional.of(user));
 
-        when(reservationService.createReservation(eq(1L), any()))
-                .thenReturn(new ReservationResponse());
+        when(reservationService.createReservation(
+                eq(1L),
+                any(ReservationRequest.class)
+        )).thenReturn(response);
 
         mockMvc.perform(post("/api/reservations")
-                        .with(user("user@mail.com"))
                         .with(csrf())
-                        .contentType(String.valueOf(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
     }
 
+    @Test
+    @WithMockUser(username = "test@gmail.com", roles = "USER")
+    void shouldReturnMyReservations() throws Exception {
+
+        ReservationResponse response = new ReservationResponse();
+        response.setId(1L);
+
+        when(reservationService.getMyReservations("test@gmail.com"))
+                .thenReturn(List.of(response));
+
+        mockMvc.perform(get("/api/reservations/my"))
+                .andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/coworking/resources/controller/reservation/ReservationSecurityTest.java
+++ b/src/test/java/com/coworking/resources/controller/reservation/ReservationSecurityTest.java
@@ -27,10 +27,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = ReservationController.class)

--- a/src/test/java/com/coworking/resources/service/reservation/ReservationServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/reservation/ReservationServiceTest.java
@@ -288,5 +288,56 @@ class ReservationServiceTest {
                 () -> reservationService.markAsPaid(1L));
     }
 
+    //mis reservaciones
+
+    @Test
+    void shouldReturnReservationsByEmail() {
+
+        Reservation reservation = new Reservation();
+        reservation.setId(1L);
+        reservation.setUser(user);
+        reservation.setRoom(room);
+        reservation.setStartAt(request.getStartAt());
+        reservation.setEndAt(request.getEndAt());
+        reservation.setStatus(ReservationStatus.PENDING);
+        reservation.setPrice(BigDecimal.valueOf(20));
+
+        when(reservationRepository
+                .findByUserEmailOrderByCreatedAtDesc("p1@email.com"))
+                .thenReturn(List.of(reservation));
+
+        List<ReservationResponse> result =
+                reservationService.getMyReservations("p1@email.com");
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+
+        ReservationResponse response = result.get(0);
+
+        assertEquals(1L, response.getId());
+        assertEquals("Sala A", response.getRoomName());
+        assertEquals("p1@email.com", response.getUsername());
+        assertEquals(ReservationStatus.PENDING, response.getStatus());
+
+        verify(reservationRepository)
+                .findByUserEmailOrderByCreatedAtDesc("p1@email.com");
+    }
+
+    //edge case
+    @Test
+    void shouldReturnEmptyListWhenUserHasNoReservations() {
+
+        when(reservationRepository
+                .findByUserEmailOrderByCreatedAtDesc("p1@email.com"))
+                .thenReturn(Collections.emptyList());
+
+        List<ReservationResponse> result =
+                reservationService.getMyReservations("p1@email.com");
+
+        assertTrue(result.isEmpty());
+
+        verify(reservationRepository)
+                .findByUserEmailOrderByCreatedAtDesc("p1@email.com");
+    }
 
 }


### PR DESCRIPTION
En este PR se implementó la funcionalidad para que el usuario autenticado pueda consultar únicamente sus propias reservaciones mediante un endpoint protegido.

Esto forma parte del módulo de gestión de reservas del usuario.

## Cambios realizados

### ReservationRepository

Se agregó consulta para obtener reservas por correo del usuario autenticado ordenadas por fecha de creación descendente.

---

### ReservationService

Se agregó método con responsabilidades:

* buscar reservas del usuario autenticado
* mapear entidades a DTOs
* retornar reservas ordenadas

---
El endpoint:

* obtiene el usuario autenticado desde Spring Security
* retorna únicamente sus reservaciones

---

## Seguridad

Se asegura que:

* el usuario solo pueda visualizar sus propias reservas
* las reservas se obtengan usando el email autenticado del JWT

---
El usuario ahora puede:

* visualizar sus propias reservaciones
* preparar flujo de cancelación
* preparar dashboard de usuario
* integrar historial y pagos posteriormente


close #81 