### PR TITLE
feat: implementar cancelacion de reservaciones

### DIFF
--- a/src/main/java/com/coworking/payment/service/StripePaymentService.java
+++ b/src/main/java/com/coworking/payment/service/StripePaymentService.java
@@ -7,7 +7,7 @@ import com.coworking.payment.enums.PaymentStatus;
 import com.coworking.payment.model.Payment;
 import com.coworking.payment.repository.PaymentRepository;
 import com.coworking.reservation.model.Reservation;
-import com.coworking.reservation.model.ReservationStatus;
+import com.coworking.reservation.enums.ReservationStatus;
 import com.coworking.reservation.repository.ReservationRepository;
 import com.stripe.exception.StripeException;
 import com.stripe.model.PaymentIntent;

--- a/src/main/java/com/coworking/reservation/controller/ReservationController.java
+++ b/src/main/java/com/coworking/reservation/controller/ReservationController.java
@@ -36,12 +36,12 @@ public class ReservationController {
     @Operation(summary = "Crear una reserva (USER o ADMIN)")
     public ReservationResponse create(@Valid @RequestBody ReservationRequest request, Authentication authentication) {
         // auth.getName() nos da el username del usuario autenticado
-      String username = authentication.getName();
-      Long userId = userRepository.findByEmail(username)
-              .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado: " + username))
-              .getId();
+        String username = authentication.getName();
+        Long userId = userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado: " + username))
+                .getId();
 
-    return reservationService.createReservation(userId, request);
+        return reservationService.createReservation(userId, request);
     }
 
     @GetMapping
@@ -51,12 +51,23 @@ public class ReservationController {
     }
 
     @GetMapping("/my")
-    public ResponseEntity<List<ReservationResponse>> getMyReservations( Authentication authentication){
+    @Operation(summary = "Listar solo mis reservas")
+    public ResponseEntity<List<ReservationResponse>> getMyReservations(Authentication authentication) {
         return ResponseEntity.ok(
                 reservationService.getMyReservations(
                         authentication.getName()
                 )
         );
+    }
+
+    @PatchMapping("/{id}/cancel")
+    @Operation(summary = "Cancelar reservacion propia")
+    public ResponseEntity<Void> cancelReservation(@PathVariable Long id, Authentication authentication) {
+        reservationService.cancelReservation(
+                id,
+                authentication.getName()
+        );
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{id}")
@@ -65,7 +76,7 @@ public class ReservationController {
         reservationService.deleteReservation(id);
     }
 
-    ///endpoint calendario de reservas(read only)
+    /// endpoint calendario de reservas(read only)
     @GetMapping("/calendar")
     @Operation(summary = "Calendario reservas por sala")
     public List<CalendarEventResponse> getCalendar(
@@ -75,7 +86,7 @@ public class ReservationController {
             @RequestParam
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
             Instant to
-    ){
+    ) {
         return reservationService.getCalendar(from, to);
     }
 }

--- a/src/main/java/com/coworking/reservation/dto/ReservationResponse.java
+++ b/src/main/java/com/coworking/reservation/dto/ReservationResponse.java
@@ -1,6 +1,6 @@
 package com.coworking.reservation.dto;
 
-import com.coworking.reservation.model.ReservationStatus;
+import com.coworking.reservation.enums.ReservationStatus;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/com/coworking/reservation/enums/ErrorCodeReservation.java
+++ b/src/main/java/com/coworking/reservation/enums/ErrorCodeReservation.java
@@ -1,0 +1,7 @@
+package com.coworking.reservation.enums;
+
+public enum ErrorCodeReservation {
+    UNAUTHORIZED_ACTION,
+    RESERVATION_ALREADY_CANCELLED,
+    RESERVATION_ALREADY_STARTED
+}

--- a/src/main/java/com/coworking/reservation/enums/ReservationStatus.java
+++ b/src/main/java/com/coworking/reservation/enums/ReservationStatus.java
@@ -1,4 +1,4 @@
-package com.coworking.reservation.model;
+package com.coworking.reservation.enums;
 
 public enum ReservationStatus {
     PENDING,

--- a/src/main/java/com/coworking/reservation/model/Reservation.java
+++ b/src/main/java/com/coworking/reservation/model/Reservation.java
@@ -1,5 +1,6 @@
 package com.coworking.reservation.model;
 
+import com.coworking.reservation.enums.ReservationStatus;
 import com.coworking.room.model.Room;
 import com.coworking.user.model.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/coworking/reservation/service/ReservationService.java
+++ b/src/main/java/com/coworking/reservation/service/ReservationService.java
@@ -7,8 +7,9 @@ import com.coworking.reservation.dto.CalendarEventResponse;
 import com.coworking.reservation.dto.ReservationRequest;
 import com.coworking.reservation.dto.ReservationResponse;
 import com.coworking.exception.ReservationConflictException;
+import com.coworking.reservation.enums.ErrorCodeReservation;
 import com.coworking.reservation.model.Reservation;
-import com.coworking.reservation.model.ReservationStatus;
+import com.coworking.reservation.enums.ReservationStatus;
 import com.coworking.room.model.Room;
 import com.coworking.user.model.User;
 import com.coworking.reservation.repository.ReservationRepository;
@@ -210,6 +211,51 @@ public class ReservationService {
 
         reservation.setStatus(ReservationStatus.PAID);
 
+        reservationRepository.save(reservation);
+    }
+
+    @Transactional
+    public void cancelReservation(Long reservationId, String email){
+
+        Reservation reservation =reservationRepository.findById(reservationId)
+                .orElseThrow(() ->
+                        new NotFoundException("Reservación no encontrada")
+                        );
+
+        //validar usuario
+
+        if (!reservation.getUser().getEmail().equals(email)) {
+            throw new ReservationConflictException(
+                    ErrorCodeReservation.UNAUTHORIZED_ACTION.name(),
+                    "No puedes cancelar esta reservación"
+            );
+        }
+
+        //evitar cancelar ya cancelada
+        if (reservation.getStatus() == ReservationStatus.CANCELLED){
+            throw new ReservationConflictException(
+                    ErrorCodeReservation.RESERVATION_ALREADY_CANCELLED.name(),
+                    "La reservación ya fue cancelada"
+            );
+        }
+
+        //Evitar cancelar reservaciones iniciadas
+        if (reservation.getStartAt().isBefore(Instant.now(clock))){
+            throw new ReservationConflictException(
+                    ErrorCodeReservation.RESERVATION_ALREADY_STARTED.name(),
+                    "No puedes cancelar una reservación iniciada"
+            );
+        }
+
+        //evitar cancelar reservas pagadas
+        if (reservation.getStatus() == ReservationStatus.PAID){
+            throw new ReservationConflictException(
+                    ErrorCodeReservation.UNAUTHORIZED_ACTION.name(),
+                    "No puedes cancelar una reservación pagada"
+            );
+        }
+
+        reservation.setStatus(ReservationStatus.CANCELLED);
         reservationRepository.save(reservation);
     }
 }

--- a/src/test/java/com/coworking/resources/controller/reservation/ReservationControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/reservation/ReservationControllerTest.java
@@ -9,15 +9,16 @@ import com.coworking.security.JwtUtil;
 import com.coworking.user.model.User;
 import com.coworking.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import java.time.Instant;
 import java.util.List;
@@ -25,14 +26,12 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(ReservationController.class)
+@WebMvcTest(controllers = ReservationController.class)
 @AutoConfigureMockMvc
 class ReservationControllerTest {
 
@@ -54,8 +53,20 @@ class ReservationControllerTest {
     @MockitoBean
     private JwtUtil jwtUtil;
 
+    @BeforeEach
+    void setUp() throws Exception {
+        doAnswer(invocation -> {
+            invocation.<jakarta.servlet.FilterChain>getArgument(2)
+                    .doFilter(
+                            invocation.getArgument(0),
+                            invocation.getArgument(1)
+                    );
+            return null;
+        }).when(jwtAuthenticationFilter)
+                .doFilter(any(), any(), any());
+    }
+
     @Test
-    @WithMockUser(username = "user@mail.com", roles = "USER")
     void createReservation_shouldReturn200() throws Exception {
 
         ReservationRequest request = new ReservationRequest();
@@ -66,12 +77,12 @@ class ReservationControllerTest {
         ReservationResponse response = new ReservationResponse();
         response.setId(1L);
 
-        User user = new User();
-        user.setId(1L);
-        user.setEmail("user@mail.com");
+        User userEntity = new User();
+        userEntity.setId(1L);
+        userEntity.setEmail("test@mail.com");
 
-        when(userRepository.findByEmail("user@mail.com"))
-                .thenReturn(Optional.of(user));
+        when(userRepository.findByEmail("test@mail.com"))
+                .thenReturn(Optional.of(userEntity));
 
         when(reservationService.createReservation(
                 eq(1L),
@@ -79,23 +90,45 @@ class ReservationControllerTest {
         )).thenReturn(response);
 
         mockMvc.perform(post("/api/reservations")
+                        .with(user("test@mail.com").roles("USER"))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
+                .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk());
     }
 
     @Test
-    @WithMockUser(username = "test@gmail.com", roles = "USER")
     void shouldReturnMyReservations() throws Exception {
 
         ReservationResponse response = new ReservationResponse();
         response.setId(1L);
 
-        when(reservationService.getMyReservations("test@gmail.com"))
+        when(reservationService.getMyReservations("test@mail.com"))
                 .thenReturn(List.of(response));
 
-        mockMvc.perform(get("/api/reservations/my"))
+        mockMvc.perform(get("/api/reservations/my")
+                        .with(user("test@mail.com").roles("USER")))
+                .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldCancelReservation() throws Exception {
+
+        doNothing().when(reservationService)
+                .cancelReservation(eq(1L), anyString());
+
+        mockMvc.perform(
+                        patch("/api/reservations/1/cancel")
+                                .with(user("test@mail.com").roles("USER"))
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk());
+
+        verify(reservationService)
+                .cancelReservation(eq(1L), anyString());
     }
 }

--- a/src/test/java/com/coworking/resources/controller/reservation/ReservationSecurityTest.java
+++ b/src/test/java/com/coworking/resources/controller/reservation/ReservationSecurityTest.java
@@ -29,6 +29,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -116,6 +117,32 @@ class ReservationSecurityTest {
         doNothing().when(reservationService).deleteReservation(anyLong());
 
         mockMvc.perform(delete("/api/reservations/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("PATCH /api/reservations/{id}/cancel - unauthenticated should return 401")
+    void cancelReservation_unauthenticated_shouldReturn401() throws Exception {
+
+        mockMvc.perform(
+                        patch("/api/reservations/1/cancel")
+                                .with(csrf())
+                )
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("PATCH /api/reservations/{id}/cancel - authenticated user should pass security")
+    void cancelReservation_authenticated_shouldPassSecurity() throws Exception {
+
+        doNothing().when(reservationService)
+                .cancelReservation(anyLong(), anyString());
+
+        mockMvc.perform(
+                        patch("/api/reservations/1/cancel")
+                                .with(csrf())
+                )
                 .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/coworking/resources/service/payment/StripePaymentServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/payment/StripePaymentServiceTest.java
@@ -7,7 +7,7 @@ import com.coworking.payment.repository.PaymentRepository;
 import com.coworking.payment.service.PaymentService;
 import com.coworking.payment.service.StripePaymentService;
 import com.coworking.reservation.model.Reservation;
-import com.coworking.reservation.model.ReservationStatus;
+import com.coworking.reservation.enums.ReservationStatus;
 import com.coworking.reservation.repository.ReservationRepository;
 import com.coworking.user.model.User;
 import com.stripe.model.PaymentIntent;

--- a/src/test/java/com/coworking/resources/service/reservation/ReservationServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/reservation/ReservationServiceTest.java
@@ -5,7 +5,7 @@ import com.coworking.reservation.dto.ReservationRequest;
 import com.coworking.reservation.dto.ReservationResponse;
 import com.coworking.exception.ReservationConflictException;
 import com.coworking.reservation.model.Reservation;
-import com.coworking.reservation.model.ReservationStatus;
+import com.coworking.reservation.enums.ReservationStatus;
 import com.coworking.room.model.Room;
 import com.coworking.user.model.User;
 import com.coworking.reservation.repository.ReservationRepository;
@@ -339,5 +339,133 @@ class ReservationServiceTest {
         verify(reservationRepository)
                 .findByUserEmailOrderByCreatedAtDesc("p1@email.com");
     }
+
+    //cancelar reservacion
+    @Test
+    void shouldCancelReservation() {
+
+        Reservation reservation = new Reservation();
+        reservation.setId(1L);
+        reservation.setUser(user);
+        reservation.setStatus(ReservationStatus.PENDING);
+        reservation.setStartAt(Instant.parse("2025-01-02T15:00:00Z"));
+
+        when(reservationRepository.findById(1L))
+                .thenReturn(Optional.of(reservation));
+
+        reservationService.cancelReservation(1L, user.getEmail());
+
+        assertEquals(
+                ReservationStatus.CANCELLED,
+                reservation.getStatus()
+        );
+
+        verify(reservationRepository).save(reservation);
+    }
+
+    //cancelar reservacion de alguien mas
+    @Test
+    void shouldThrowWhenCancellingAnotherUsersReservation() {
+
+        Reservation reservation = new Reservation();
+
+        User anotherUser = new User();
+        anotherUser.setEmail("other@email.com");
+
+        reservation.setUser(anotherUser);
+        reservation.setStatus(ReservationStatus.PENDING);
+        reservation.setStartAt(Instant.parse("2025-01-02T15:00:00Z"));
+
+        when(reservationRepository.findById(1L))
+                .thenReturn(Optional.of(reservation));
+
+        assertThrows(
+                ReservationConflictException.class,
+                () -> reservationService.cancelReservation(
+                        1L,
+                        "p1@email.com"
+                )
+        );
+
+        verify(reservationRepository, never()).save(any());
+    }
+
+    //impedir cancelar iniciada
+    @Test
+    void shouldThrowWhenReservationAlreadyStarted() {
+
+        Reservation reservation = new Reservation();
+        reservation.setUser(user);
+        reservation.setStatus(ReservationStatus.PENDING);
+
+        reservation.setStartAt(
+                Instant.parse("2024-12-31T10:00:00Z")
+        );
+
+        when(reservationRepository.findById(1L))
+                .thenReturn(Optional.of(reservation));
+
+        assertThrows(
+                ReservationConflictException.class,
+                () -> reservationService.cancelReservation(
+                        1L,
+                        user.getEmail()
+                )
+        );
+
+        verify(reservationRepository, never()).save(any());
+    }
+
+    //impedir cancelar ya cancelada
+    @Test
+    void shouldThrowWhenReservationAlreadyCancelled() {
+
+        Reservation reservation = new Reservation();
+        reservation.setUser(user);
+        reservation.setStatus(ReservationStatus.CANCELLED);
+        reservation.setStartAt(
+                Instant.parse("2025-01-02T15:00:00Z")
+        );
+
+        when(reservationRepository.findById(1L))
+                .thenReturn(Optional.of(reservation));
+
+        assertThrows(
+                ReservationConflictException.class,
+                () -> reservationService.cancelReservation(
+                        1L,
+                        user.getEmail()
+                )
+        );
+
+        verify(reservationRepository, never()).save(any());
+    }
+
+    //impedir cancelar pagadas
+    @Test
+    void shouldThrowWhenReservationIsPaid() {
+
+        Reservation reservation = new Reservation();
+        reservation.setUser(user);
+        reservation.setStatus(ReservationStatus.PAID);
+        reservation.setStartAt(
+                Instant.parse("2025-01-02T15:00:00Z")
+        );
+
+        when(reservationRepository.findById(1L))
+                .thenReturn(Optional.of(reservation));
+
+        assertThrows(
+                ReservationConflictException.class,
+                () -> reservationService.cancelReservation(
+                        1L,
+                        user.getEmail()
+                )
+        );
+
+        verify(reservationRepository, never()).save(any());
+    }
+
+
 
 }


### PR DESCRIPTION
En este PR se implementa la cancelación segura de reservaciones por usuarios autenticados.

## Cambios realizados

- Se agregó endpoint PATCH /api/reservations/{id}/cancel
- Se validó propietario de reservación
- Se impidió cancelar reservaciones:
    - ajenas
    - iniciadas
    - ya canceladas
    - pagadas
- Se creo ErrorCodeReservation
- Se agregaron pruebas unitarias y de seguridad

## Tests

- ReservationServiceTest
- ReservationControllerTest
- ReservationSecurityTest

## Resultado

Los usuarios ahora pueden cancelar únicamente sus reservaciones pendientes de manera segura.

closes #83 