### PR TITLE
fix: mostrar solo reservas PAID en el calendario

### DIFF
--- a/src/main/java/com/coworking/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/coworking/reservation/repository/ReservationRepository.java
@@ -37,6 +37,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             Instant end,
             Instant start);
 
+    List<Reservation> findByStatusAndStartAtLessThanAndEndAtGreaterThan(
+            ReservationStatus status,
+            Instant end,
+            Instant start
+    );
+
     //overlapping
     boolean existsByRoomIdAndStartAtLessThanAndEndAtGreaterThan(
             Long roomId,

--- a/src/main/java/com/coworking/reservation/service/ReservationService.java
+++ b/src/main/java/com/coworking/reservation/service/ReservationService.java
@@ -190,7 +190,11 @@ public class ReservationService {
             Instant to
     ) {
         return reservationRepository
-                .findByStartAtLessThanAndEndAtGreaterThan(to, from)
+                .findByStatusAndStartAtLessThanAndEndAtGreaterThan(
+                        ReservationStatus.PAID,
+                        to,
+                        from
+                )
                 .stream()
                 .map(r -> new CalendarEventResponse(
                         r.getRoom().getName(),


### PR DESCRIPTION
En este PR se actualizó la lógica del calendario de reservas para mostrar únicamente reservas pagadas (`PAID`).

## Cambios realizados

* Se agregó un método en `ReservationRepository` para filtrar reservas por estado y rango de fechas.
* Se modificó `getCalendar()` en `ReservationService` para retornar solo reservas con estado `PAID`.

## Resultado

El calendario ya no muestra reservas:

* `PENDING`
* `CANCELLED`
* `EXPIRED`

Ahora únicamente se visualizan horarios realmente confirmados mediante pago.

close #90 
