### PR TITLE
feat/agregar exportación CSV para reportes administrativos

### DIFF
--- a/src/main/java/com/coworking/reports/controller/ReportController.java
+++ b/src/main/java/com/coworking/reports/controller/ReportController.java
@@ -1,0 +1,47 @@
+package com.coworking.reports.controller;
+
+import com.coworking.reports.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @GetMapping("/reservations")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<byte[]> exportReservationsCsv(){
+        return ResponseEntity.ok()
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=reservations.csv"
+                )
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(
+                        reportService.exportReservationsCsv()
+                );
+    }
+
+    @GetMapping("/payments")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<byte[]> exportPaymentsCsv(){
+        return ResponseEntity.ok()
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=payments.csv"
+                )
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(
+                        reportService.exportPaymentsCsv()
+                );
+    }
+}

--- a/src/main/java/com/coworking/reports/service/ReportService.java
+++ b/src/main/java/com/coworking/reports/service/ReportService.java
@@ -1,0 +1,7 @@
+package com.coworking.reports.service;
+
+public interface ReportService {
+
+    byte[] exportReservationsCsv();
+    byte[] exportPaymentsCsv();
+}

--- a/src/main/java/com/coworking/reports/service/ReportServiceImpl.java
+++ b/src/main/java/com/coworking/reports/service/ReportServiceImpl.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class ReportServiceImple implements ReportService{
+public class ReportServiceImpl implements ReportService{
 
     private final ReservationRepository reservationRepository;
     private final PaymentRepository paymentRepository;

--- a/src/main/java/com/coworking/reports/service/ReportServiceImple.java
+++ b/src/main/java/com/coworking/reports/service/ReportServiceImple.java
@@ -1,0 +1,61 @@
+package com.coworking.reports.service;
+
+import com.coworking.payment.model.Payment;
+import com.coworking.payment.repository.PaymentRepository;
+import com.coworking.reservation.model.Reservation;
+import com.coworking.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportServiceImple implements ReportService{
+
+    private final ReservationRepository reservationRepository;
+    private final PaymentRepository paymentRepository;
+
+    @Override
+    public byte[] exportReservationsCsv() {
+        List<Reservation> reservations =
+                reservationRepository.findAll();
+
+        StringBuilder csv = new StringBuilder();
+        csv.append("ID,Usuario,Sala,Inicio,Fin,Precio,Estado\n");
+
+        for(Reservation reservation : reservations){
+            csv.append(reservation.getId()).append(",");
+            csv.append(reservation.getUser().getEmail()).append(",");
+            csv.append(reservation.getRoom().getName()).append(",");
+            csv.append(reservation.getStartAt()).append(",");
+            csv.append(reservation.getEndAt()).append(",");
+            csv.append(reservation.getPrice()).append(",");
+            csv.append(reservation.getStatus()).append("\n");
+        }
+
+        return csv.toString()
+                .getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public byte[] exportPaymentsCsv() {
+        List<Payment> payments =
+                paymentRepository.findAll();
+
+        StringBuilder csv = new StringBuilder();
+        csv.append("ID,Reserva,Sala,Monto,Metodo,Estado,FechaPago\n");
+        for(Payment payment : payments){
+            csv.append(payment.getId()).append(",");
+            csv.append(payment.getReservation().getId()).append(",");
+            csv.append(payment.getReservation().getRoom().getName()).append(",");
+            csv.append(payment.getAmount()).append(",");
+            csv.append(payment.getPaymentMethod()).append(",");
+            csv.append(payment.getStatus()).append(",");
+            csv.append(payment.getPaidAt()).append("\n");
+        }
+        return csv.toString()
+                .getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/com/coworking/resources/controller/reports/ReportControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/reports/ReportControllerTest.java
@@ -1,0 +1,94 @@
+package com.coworking.resources.controller.reports;
+
+import com.coworking.reports.controller.ReportController;
+import com.coworking.reports.service.ReportService;
+import com.coworking.security.JwtAuthenticationFilter;
+import com.coworking.security.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+import static org.hamcrest.Matchers.containsString;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ReportController.class)
+@AutoConfigureMockMvc
+class ReportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ReportService reportService;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() throws Exception {
+
+        doAnswer(invocation -> {
+            invocation.<jakarta.servlet.FilterChain>getArgument(2)
+                    .doFilter(
+                            invocation.getArgument(0),
+                            invocation.getArgument(1)
+                    );
+            return null;
+        }).when(jwtAuthenticationFilter)
+                .doFilter(any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void shouldExportReservationsCsv() throws Exception {
+
+        when(reportService.exportReservationsCsv())
+                .thenReturn(
+                        "ID,Usuario,Sala\n1,dayana,Sala A"
+                                .getBytes()
+                );
+
+        mockMvc.perform(
+                        get("/admin/reports/reservations")
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string(
+                        "Content-Disposition",
+                        containsString("reservations.csv")
+                ));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void shouldExportPaymentsCsv() throws Exception {
+
+        when(reportService.exportPaymentsCsv())
+                .thenReturn(
+                        "ID,Reserva,Sala\n1,1,Sala A"
+                                .getBytes()
+                );
+
+        mockMvc.perform(
+                        get("/admin/reports/payments")
+                )
+                .andExpect(status().isOk())
+                .andExpect(header().string(
+                        "Content-Disposition",
+                        containsString("payments.csv")
+                ));
+    }
+}

--- a/src/test/java/com/coworking/resources/controller/reports/ReportSecurityTest.java
+++ b/src/test/java/com/coworking/resources/controller/reports/ReportSecurityTest.java
@@ -1,0 +1,115 @@
+package com.coworking.resources.controller.reports;
+
+import com.coworking.reports.controller.ReportController;
+import com.coworking.reports.service.ReportService;
+import com.coworking.security.AuthenticationEntryPointImpl;
+import com.coworking.security.CustomUserDetailsService;
+import com.coworking.security.JwtAuthenticationFilter;
+import com.coworking.security.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+
+import org.springframework.context.annotation.Bean;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReportController.class)
+@AutoConfigureMockMvc
+class ReportSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ReportService reportService;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private AuthenticationEntryPointImpl authenticationEntryPoint;
+
+    @MockitoBean
+    private AuthenticationProvider authenticationProvider;
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http)
+                throws Exception {
+
+            return http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .exceptionHandling(ex ->
+                            ex.authenticationEntryPoint(
+                                    (request, response, authException) ->
+                                            response.sendError(
+                                                    HttpServletResponse.SC_UNAUTHORIZED
+                                            )
+                            )
+                    )
+                    .authorizeHttpRequests(auth -> auth
+                            .requestMatchers("/admin/**")
+                            .hasRole("ADMIN")
+                            .anyRequest()
+                            .authenticated()
+                    )
+                    .build();
+        }
+    }
+
+    @Test
+    void shouldReturn401WhenUnauthenticated()
+            throws Exception {
+
+        mockMvc.perform(
+                        get("/admin/reports/reservations")
+                )
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void shouldReturn403WhenUserRole()
+            throws Exception {
+
+        mockMvc.perform(
+                        get("/admin/reports/reservations")
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void shouldAllowAdminAccess()
+            throws Exception {
+
+        mockMvc.perform(
+                        get("/admin/reports/reservations")
+                )
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/coworking/resources/service/reports/ReportServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/reports/ReportServiceTest.java
@@ -1,7 +1,7 @@
 package com.coworking.resources.service.reports;
 
 import com.coworking.payment.repository.PaymentRepository;
-import com.coworking.reports.service.ReportServiceImple;
+import com.coworking.reports.service.ReportServiceImpl;
 import com.coworking.reservation.enums.ReservationStatus;
 import com.coworking.reservation.model.Reservation;
 import com.coworking.reservation.repository.ReservationRepository;
@@ -14,7 +14,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -32,7 +31,7 @@ class ReportServiceTest {
     private PaymentRepository paymentRepository;
 
     @InjectMocks
-    private ReportServiceImple reportService;
+    private ReportServiceImpl reportService;
 
     @Test
     void shouldGenerateReservationsCsv() {

--- a/src/test/java/com/coworking/resources/service/reports/ReportServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/reports/ReportServiceTest.java
@@ -1,0 +1,67 @@
+package com.coworking.resources.service.reports;
+
+import com.coworking.payment.repository.PaymentRepository;
+import com.coworking.reports.service.ReportServiceImple;
+import com.coworking.reservation.enums.ReservationStatus;
+import com.coworking.reservation.model.Reservation;
+import com.coworking.reservation.repository.ReservationRepository;
+import com.coworking.room.model.Room;
+import com.coworking.user.model.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @InjectMocks
+    private ReportServiceImple reportService;
+
+    @Test
+    void shouldGenerateReservationsCsv() {
+
+        User user = new User();
+        user.setEmail("test@test.com");
+
+        Room room = new Room();
+        room.setName("Sala A");
+
+        Reservation reservation = new Reservation();
+        reservation.setId(1L);
+        reservation.setUser(user);
+        reservation.setRoom(room);
+        reservation.setStartAt(LocalDateTime.of(2025, 1, 1, 10, 0).toInstant(ZoneOffset.UTC));
+        reservation.setEndAt(LocalDateTime.of(2025, 1, 1, 12, 0).toInstant(ZoneOffset.UTC));
+        reservation.setPrice(BigDecimal.valueOf(50));
+        reservation.setStatus(ReservationStatus.valueOf("PAID"));
+
+        when(reservationRepository.findAll())
+                .thenReturn(List.of(reservation));
+
+        byte[] csv = reportService.exportReservationsCsv();
+
+        String content = new String(csv);
+
+        assertTrue(content.contains("ID"));
+        assertTrue(content.contains("test@test.com"));
+        assertTrue(content.contains("Sala A"));
+        assertTrue(content.contains("50"));
+    }
+}


### PR DESCRIPTION
En este PR se implementó la exportación de reportes administrativos en formato CSV.

## Funcionalidades

### Reservas

Nuevo endpoint:

GET /admin/reports/reservations

### Pagos

Nuevo endpoint:

GET /admin/reports/payments


### Tests

Se agregaron pruebas para:

- ReportController
- Seguridad de endpoints
- Generación de CSV en ReportService

## Resultado

Los administradores pueden descargar reportes de reservas y pagos para análisis y respaldo de información.
-------------------------------------------------------------

closes #96 