### PR TITLE
feat/soporte de actualización de salas con imágenes

### DIFF
--- a/src/main/java/com/coworking/room/controller/RoomController.java
+++ b/src/main/java/com/coworking/room/controller/RoomController.java
@@ -40,11 +40,14 @@ public class RoomController {
     }
 
     //Actualizar
-    @PutMapping("/{id}")
+    @PutMapping(value = "/{id}", consumes = "multipart/form-data")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Actualizar sala existente(solo ADMIN)")
-    public ResponseEntity<RoomDto> actualizarRoom(@PathVariable Long id, @RequestBody RoomDto dto){
-        return roomService.updateRoom(id, dto)
+    public ResponseEntity<RoomDto> actualizarRoom(
+            @PathVariable Long id,
+            @RequestPart("room") RoomDto dto,
+            @RequestPart(value = "image", required = false) MultipartFile image){
+        return roomService.updateRoom(id, dto, image)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/src/main/java/com/coworking/room/service/RoomService.java
+++ b/src/main/java/com/coworking/room/service/RoomService.java
@@ -102,7 +102,7 @@ public class RoomService {
         return mapToDto(roomRepository.save(room));
     }
 
-    public Optional<RoomDto> updateRoom(Long id, RoomDto dto){
+    public Optional<RoomDto> updateRoom(Long id, RoomDto dto, MultipartFile image){
 
         return roomRepository.findById(id).map(room -> {
 
@@ -111,9 +111,13 @@ public class RoomService {
             room.setCapacity(dto.getCapacity());
             room.setAvailable(dto.isAvailable());
             room.setPrice(dto.getPrice());
-            room.setImageUrl(dto.getImageUrl());
             room.setLocation(dto.getLocation());
             room.setFeatures(dto.getFeatures());
+
+            if (image != null && !image.isEmpty()) {
+                String imageUrl = storageService.upload(image);
+                room.setImageUrl(imageUrl);
+            }
 
             return mapToDto(roomRepository.save(room));
         });

--- a/src/test/java/com/coworking/resources/controller/room/RoomControllerSecurityTest.java
+++ b/src/test/java/com/coworking/resources/controller/room/RoomControllerSecurityTest.java
@@ -75,11 +75,11 @@ public class RoomControllerSecurityTest {
                         "",
                         "application/json",
                         """
-                        {
-                          "name":"Sala Nueva",
-                          "capacity":10
-                        }
-                        """.getBytes()
+                                {
+                                  "name":"Sala Nueva",
+                                  "capacity":10
+                                }
+                                """.getBytes()
                 );
 
         mockMvc.perform(
@@ -99,19 +99,29 @@ public class RoomControllerSecurityTest {
         dto.setId(1L);
         dto.setName("Sala Editada");
 
-        when(roomService.updateRoom(eq(1L), any(RoomDto.class)))
+        when(roomService.updateRoom(eq(1L), any(RoomDto.class), any()))
                 .thenReturn(Optional.of(dto));
 
+        MockMultipartFile room =
+                new MockMultipartFile(
+                        "room",
+                        "",
+                        "application/json",
+                        """
+                                {
+                                  "name":"Sala Editada"
+                                }
+                                """.getBytes()
+                );
+
         mockMvc.perform(
-                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-                                .put("/api/rooms/1")
-                                .contentType("application/json")
-                                .content("""
-                        {
-                          "name":"Sala Editada"
-                        }
-                    """)
+                        multipart("/api/rooms/1")
+                                .file(room)
                                 .with(csrf())
+                                .with(request -> {
+                                    request.setMethod("PUT");
+                                    return request;
+                                })
                 )
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/coworking/resources/service/room/RoomServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/room/RoomServiceTest.java
@@ -35,6 +35,7 @@ class RoomServiceTest {
 
     private Room room;
     private RoomDto baseRoomDto;
+    private MockMultipartFile image;
 
     @BeforeEach
     void setUp() {
@@ -62,6 +63,13 @@ class RoomServiceTest {
         baseRoomDto.setLocation("Ubicación Test");
         baseRoomDto.setFeatures(List.of("Wifi", "Pizarra"));
         baseRoomDto.setImageUrl("/uploads/mock-image.jpg");
+
+        image = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "contenido".getBytes()
+        );
 
     }
 
@@ -141,31 +149,6 @@ class RoomServiceTest {
     }
 
     @Test
-    void updateRoom_updatesExistingRoom() {
-        when(roomRepository.findById(1L)).thenReturn(Optional.of(room));
-
-        RoomDto dto = new RoomDto();
-        dto.setName("Sala modificada");
-        dto.setDescription("Actualizada");
-        dto.setCapacity(15);
-        dto.setPrice(new BigDecimal("15.00"));
-        dto.setAvailable(false);
-        // Mantenemos la URL existente o la omitimos si el DTO no la incluye
-        dto.setImageUrl(room.getImageUrl());
-        // Configurar el save para devolver la misma entidad modificada
-        when(roomRepository.save(any(Room.class))).thenReturn(room);
-
-        Optional<RoomDto> result = roomService.updateRoom(1L, dto);
-
-        assertTrue(result.isPresent());
-        assertEquals("Sala modificada", result.get().getName());
-        assertEquals(15, result.get().getCapacity());
-        assertEquals(new BigDecimal("15.00"), result.get().getPrice());
-        // Verificamos que la URL de imagen no se perdió si se incluyó en el DTO
-        assertEquals("/uploads/mock-image.jpg", result.get().getImageUrl());
-    }
-
-    @Test
     void getRoomById_notFound_returnsEmpty() {
         when(roomRepository.findById(1L)).thenReturn(Optional.empty());
 
@@ -219,7 +202,7 @@ class RoomServiceTest {
                 .thenReturn(Optional.empty());
 
         Optional<RoomDto> result =
-                roomService.updateRoom(1L, new RoomDto());
+                roomService.updateRoom(1L, new RoomDto(), image);
 
         assertTrue(result.isEmpty());
 
@@ -262,5 +245,67 @@ class RoomServiceTest {
         verify(storageService).upload(image);
         verify(roomRepository).save(any(Room.class));
     }
+    //update
+    @Test
+    void updateRoom_updatesExistingRoom_withoutImage() {
+
+        when(roomRepository.findById(1L))
+                .thenReturn(Optional.of(room));
+
+        when(roomRepository.save(any(Room.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        RoomDto dto = new RoomDto();
+        dto.setName("Sala modificada");
+        dto.setDescription("Actualizada");
+        dto.setCapacity(15);
+        dto.setPrice(new BigDecimal("15.00"));
+        dto.setAvailable(false);
+        dto.setLocation("Nueva ubicación");
+        dto.setFeatures(List.of("Wifi"));
+
+        Optional<RoomDto> result =
+                roomService.updateRoom(1L, dto, null);
+
+        assertTrue(result.isPresent());
+        assertEquals("Sala modificada", result.get().getName());
+        assertEquals(15, result.get().getCapacity());
+        assertEquals(new BigDecimal("15.00"), result.get().getPrice());
+
+        verify(storageService, never()).upload(any());
+    }
+
+    @Test
+    void updateRoom_withImage_updatesImageUrl() {
+
+        when(roomRepository.findById(1L))
+                .thenReturn(Optional.of(room));
+
+        when(storageService.upload(image))
+                .thenReturn("/uploads/new-image.jpg");
+
+        when(roomRepository.save(any(Room.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        RoomDto dto = new RoomDto();
+        dto.setName("Sala modificada");
+        dto.setDescription("Actualizada");
+        dto.setCapacity(15);
+        dto.setPrice(new BigDecimal("15.00"));
+        dto.setAvailable(false);
+
+        Optional<RoomDto> result =
+                roomService.updateRoom(1L, dto, image);
+
+        assertTrue(result.isPresent());
+
+        assertEquals(
+                "/uploads/new-image.jpg",
+                result.get().getImageUrl()
+        );
+
+        verify(storageService).upload(image);
+    }
+
 }
 


### PR DESCRIPTION
En este PR se actualiza el flujo de edición de salas para soportar la carga y actualización de imágenes utilizando multipart/form-data, alineando el comportamiento del endpoint de actualización con el endpoint de creación.

--------
closes #101 