### PR TITLE
Manejar conflicto al eliminar salas con reservas asociadas

### DIFF
--- a/src/main/java/com/coworking/exception/ErrorCode.java
+++ b/src/main/java/com/coworking/exception/ErrorCode.java
@@ -12,5 +12,6 @@ public enum ErrorCode {
     NOT_FOUND,
     BAD_REQUEST,
     UNAUTHORIZED,
-    INTERNAL_ERROR
+    INTERNAL_ERROR,
+    CONFLICT;
 }

--- a/src/main/java/com/coworking/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/coworking/exception/GlobalExceptionHandler.java
@@ -81,6 +81,19 @@ public class GlobalExceptionHandler {
         );
     }
 
+    @ExceptionHandler(RoomHasReservationsException.class)
+    public ResponseEntity<ApiError> handleRoomHasReservations(
+            RoomHasReservationsException ex,
+            HttpServletRequest request) {
+
+        return buildError(
+                HttpStatus.CONFLICT,
+                ex.getMessage(),
+                request,
+                ErrorCode.CONFLICT.name()
+        );
+    }
+
     // CONFLICT (reservas)
     @ExceptionHandler(ReservationConflictException.class)
     public ResponseEntity<ApiError> handleConflict(

--- a/src/main/java/com/coworking/exception/RoomHasReservationsException.java
+++ b/src/main/java/com/coworking/exception/RoomHasReservationsException.java
@@ -1,0 +1,7 @@
+package com.coworking.exception;
+
+public class RoomHasReservationsException extends RuntimeException {
+    public RoomHasReservationsException() {
+        super("La sala tiene reservas asociadas");
+    }
+}

--- a/src/main/java/com/coworking/room/service/RoomService.java
+++ b/src/main/java/com/coworking/room/service/RoomService.java
@@ -1,5 +1,6 @@
 package com.coworking.room.service;
 
+import com.coworking.exception.RoomHasReservationsException;
 import com.coworking.room.dto.RoomAvailabilityResponse;
 import com.coworking.room.dto.RoomDto;
 import com.coworking.reservation.model.Reservation;
@@ -8,6 +9,7 @@ import com.coworking.reservation.repository.ReservationRepository;
 import com.coworking.room.repository.RoomRepository;
 import com.coworking.storage.service.StorageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -123,12 +125,21 @@ public class RoomService {
         });
     }
 
+    @Transactional
     public boolean deleteRoom(Long id){
 
-        if(!roomRepository.existsById(id)) return false;
+        if(!roomRepository.existsById(id)) {
+            return false;
+        }
 
-        roomRepository.deleteById(id);
-        return true;
+        try {
+            roomRepository.deleteById(id);
+            roomRepository.flush();
+
+            return true;
+        } catch (DataIntegrityViolationException ex) {
+            throw new RoomHasReservationsException();
+        }
     }
 
     // ROOM AVAILABILITY


### PR DESCRIPTION
En este PR se mejoro la eliminación de salas para manejar correctamente los casos donde existen reservas asociadas.

**Cambios**

- Se creó RoomHasReservationsException.
- Se agregó un handler que responde con 409 Conflict.
- Se actualizó deleteRoom() para capturar errores de integridad referencial y lanzar una excepción de negocio.
- Se agregó flush() para ejecutar la eliminación inmediatamente dentro de la transacción.

**Resultado**
Caso | Respuesta
-- | --
Sala eliminada | 204
Sala no encontrada | 404
Sala con reservas asociadas | 409

-------------
Evita errores 500 y permite informar claramente cuando una sala no puede eliminarse porque tiene reservas asociadas.
