### PR TITLE
feat(admin): Agregar listado administrativo de usuarios

### DIFF
--- a/src/main/java/com/coworking/admin/controller/AdminController.java
+++ b/src/main/java/com/coworking/admin/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.coworking.admin.controller;
 
 
 import com.coworking.admin.dto.AdminStatsResponse;
+import com.coworking.admin.dto.UserAdminResponse;
 import com.coworking.admin.service.AdminService;
 import com.coworking.dto.common.ApiResponseDto;
 import com.coworking.payment.dto.PaymentResponse;
@@ -23,7 +24,7 @@ public class AdminController {
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                      Dashboard stats
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
-
+    // Devuelve métricas generales para el dashboard administrativo
     @GetMapping("/stats")
     public ResponseEntity<AdminStatsResponse> getStats(){
         return  ResponseEntity.ok(
@@ -34,7 +35,7 @@ public class AdminController {
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                     All reservations
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
-
+    // Obtiene todas las reservas registradas en el sistema
     @GetMapping("/reservations")
     public ResponseEntity<List<ReservationResponse>> getReservations(){
         return ResponseEntity.ok(
@@ -45,7 +46,7 @@ public class AdminController {
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                       All payments
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
-
+    // Obtiene todos los pagos registrados
     @GetMapping("/payments")
     public ResponseEntity<List<PaymentResponse>> getPayments(){
         return ResponseEntity.ok(
@@ -56,7 +57,7 @@ public class AdminController {
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                   Cancel reservation
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
-
+    // Permite cancelar una reserva desde el panel administrativo
     @PatchMapping("/reservations/{id}/cancel")
     public ResponseEntity<ApiResponseDto<String>> cancelReservation(@PathVariable Long id){
         adminService.cancelReservation(id);
@@ -70,5 +71,15 @@ public class AdminController {
         );
     }
 
+    // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+    //                         All Users
+    // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+    // Obtiene todos los usuarios registrados para administración
+    @GetMapping("/users")
+    public ResponseEntity<List<UserAdminResponse>> getUsers(){
+        return ResponseEntity.ok(
+                adminService.getAllUsers()
+        );
+    }
 
 }

--- a/src/main/java/com/coworking/admin/dto/UserAdminResponse.java
+++ b/src/main/java/com/coworking/admin/dto/UserAdminResponse.java
@@ -1,0 +1,23 @@
+package com.coworking.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserAdminResponse {
+
+    private Long id;
+
+    private String username;
+
+    private String email;
+
+    private Set<String> roles;
+
+    private boolean enabled;
+}

--- a/src/main/java/com/coworking/admin/service/AdminService.java
+++ b/src/main/java/com/coworking/admin/service/AdminService.java
@@ -1,6 +1,7 @@
 package com.coworking.admin.service;
 
 import com.coworking.admin.dto.AdminStatsResponse;
+import com.coworking.admin.dto.UserAdminResponse;
 import com.coworking.payment.dto.PaymentResponse;
 import com.coworking.reservation.dto.ReservationResponse;
 
@@ -8,11 +9,18 @@ import java.util.List;
 
 public interface AdminService {
 
+    // Dashboard
     AdminStatsResponse getStats();
 
+    // Reservas
     List<ReservationResponse> getAllReservations();
 
+    // Pagos
     List<PaymentResponse> getAllPayments();
 
+    // Usuarios
+    List<UserAdminResponse> getAllUsers();
+
+    // Administración de reservas
     void cancelReservation(Long reservationId);
 }

--- a/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
@@ -1,6 +1,7 @@
 package com.coworking.admin.service;
 
 import com.coworking.admin.dto.AdminStatsResponse;
+import com.coworking.admin.dto.UserAdminResponse;
 import com.coworking.exception.NotFoundException;
 import com.coworking.payment.dto.PaymentResponse;
 import com.coworking.payment.model.Payment;
@@ -9,11 +10,16 @@ import com.coworking.reservation.dto.ReservationResponse;
 import com.coworking.reservation.enums.ReservationStatus;
 import com.coworking.reservation.model.Reservation;
 import com.coworking.reservation.repository.ReservationRepository;
+import com.coworking.role.model.Role;
+import com.coworking.user.model.User;
+import com.coworking.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +27,7 @@ public class AdminServiceImpl implements AdminService {
 
     private final ReservationRepository reservationRepository;
     private final PaymentRepository paymentRepository;
+    private final UserRepository userRepository;
 
     @Override
     public AdminStatsResponse getStats() {
@@ -39,6 +46,7 @@ public class AdminServiceImpl implements AdminService {
         long expiredReservations =
                 reservationRepository.countByStatus(ReservationStatus.EXPIRED);
 
+        // Construye las métricas mostradas en el dashboard administrativo
         return AdminStatsResponse.builder()
                 .totalReservations(totalReservations)
                 .activeReservations(activeReservations)
@@ -50,6 +58,7 @@ public class AdminServiceImpl implements AdminService {
                 .build();
     }
 
+    // Obtiene todas las reservas y las transforma a DTO de respuesta
     @Override
     public List<ReservationResponse> getAllReservations() {
 
@@ -59,6 +68,7 @@ public class AdminServiceImpl implements AdminService {
                 .toList();
     }
 
+    // Obtiene todos los pagos y los transforma a DTO de respuesta
     @Override
     public List<PaymentResponse> getAllPayments() {
 
@@ -68,6 +78,7 @@ public class AdminServiceImpl implements AdminService {
                 .toList();
     }
 
+    // Cancela una reserva independientemente de su propietario
     @Override
     @Transactional
     public void cancelReservation(Long reservationId) {
@@ -82,8 +93,17 @@ public class AdminServiceImpl implements AdminService {
 
     }
 
+    // Obtiene todos los usuarios registrados para la vista administrativa
+    public List<UserAdminResponse> getAllUsers(){
+        return userRepository.findAll()
+                .stream()
+                .map(this::mapToUserAdminResponse)
+                .toList();
+    }
+
     // MAPPERS
 
+    // Convierte una entidad Reservation a ReservationResponse
     private ReservationResponse mapReservationToResponse(Reservation reservation) {
 
         ReservationResponse response = new ReservationResponse();
@@ -100,6 +120,7 @@ public class AdminServiceImpl implements AdminService {
         return response;
     }
 
+    // Convierte una entidad Payment a PaymentResponse
     private PaymentResponse mapPaymentToResponse(Payment payment) {
 
         return PaymentResponse.builder()
@@ -111,5 +132,21 @@ public class AdminServiceImpl implements AdminService {
                 .status(payment.getStatus())
                 .paidAt(payment.getPaidAt())
                 .build();
+    }
+
+    // Convierte una entidad User a UserAdminResponse
+    private UserAdminResponse mapToUserAdminResponse(User user){
+        Set<String> roles = user.getRoles()
+                .stream()
+                .map(Role::getName)
+                .collect(Collectors.toSet());
+
+        return new UserAdminResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getEmail(),
+                roles,
+                user.isEnabled()
+        );
     }
 }

--- a/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
@@ -2,6 +2,7 @@ package com.coworking.resources.controller.admin;
 
 import com.coworking.admin.controller.AdminController;
 import com.coworking.admin.dto.AdminStatsResponse;
+import com.coworking.admin.dto.UserAdminResponse;
 import com.coworking.admin.service.AdminService;
 import com.coworking.payment.dto.PaymentResponse;
 import com.coworking.payment.enums.PaymentStatus;
@@ -22,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -144,5 +146,28 @@ class AdminControllerTest {
 
         verify(adminService)
                 .cancelReservation(1L);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void shouldReturnAllUsers() throws Exception {
+        UserAdminResponse user =
+                new UserAdminResponse(
+                        1L,
+                        "dayana",
+                        "dayana@gmail.com",
+                        Set.of("ROLE_USER"),
+                        true
+                );
+
+        when(adminService.getAllUsers())
+                .thenReturn(List.of(user));
+
+        mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].username")
+                        .value("dayana"))
+                .andExpect(jsonPath("$[0].email")
+                        .value("dayana@gmail.com"));
     }
 }

--- a/src/test/java/com/coworking/resources/controller/admin/AdminSecurityTest.java
+++ b/src/test/java/com/coworking/resources/controller/admin/AdminSecurityTest.java
@@ -112,4 +112,21 @@ class AdminSecurityTest {
                 )
                 .andExpect(status().isForbidden());
     }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void userShouldNotAccessUsers() throws Exception {
+
+        mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isForbidden());
+    }
+
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void adminShouldAccessUsers() throws Exception {
+
+        mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
@@ -1,11 +1,15 @@
 package com.coworking.resources.service.admin;
 
 import com.coworking.admin.dto.AdminStatsResponse;
+import com.coworking.admin.dto.UserAdminResponse;
 import com.coworking.admin.service.AdminServiceImpl;
 import com.coworking.payment.repository.PaymentRepository;
 import com.coworking.reservation.enums.ReservationStatus;
 import com.coworking.reservation.model.Reservation;
 import com.coworking.reservation.repository.ReservationRepository;
+import com.coworking.role.model.Role;
+import com.coworking.user.model.User;
+import com.coworking.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,9 +17,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.security.PrivateKey;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +35,9 @@ class AdminServiceTest {
 
     @Mock
     private PaymentRepository paymentRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private AdminServiceImpl adminService;
@@ -64,10 +75,10 @@ class AdminServiceTest {
     // Cancel reservation
 
     @Test
-    void shouldCancelReservation(){
+    void shouldCancelReservation() {
         Reservation reservation = new Reservation();
         reservation.setId(1L);
-        reservation.setStatus(ReservationStatus.CANCELLED);
+        reservation.setStatus(ReservationStatus.PAID);
 
         when(reservationRepository.findById(1L))
                 .thenReturn(Optional.of(reservation));
@@ -80,5 +91,54 @@ class AdminServiceTest {
         );
 
         verify(reservationRepository).save(reservation);
+    }
+
+    //lista de usuarios
+    @Test
+    void shouldReturnAllUsers() {
+
+        // Arrange
+        Role role = new Role();
+        role.setName("ROLE_USER");
+
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("dayana");
+        user.setEmail("dayana@gmail.com");
+        user.setEnabled(true);
+        user.setRoles(Set.of(role));
+
+        when(userRepository.findAll())
+                .thenReturn(List.of(user));
+
+        // Act
+        List<UserAdminResponse> result =
+                adminService.getAllUsers();
+
+        // Assert
+        assertEquals(1, result.size());
+
+        assertEquals(
+                "dayana",
+                result.getFirst().getUsername()
+        );
+
+        assertEquals(
+                "dayana@gmail.com",
+                result.getFirst().getEmail()
+        );
+
+        assertTrue(
+                result.getFirst()
+                        .getRoles()
+                        .contains("ROLE_USER")
+        );
+
+        assertTrue(
+                result.getFirst()
+                        .isEnabled()
+        );
+
+        verify(userRepository).findAll();
     }
 }


### PR DESCRIPTION
En este PR se implementa el listado administrativo de usuarios para el panel de administración.

## Cambios realizados

- Se creó el DTO UserAdminResponse.
- Se agregó el método getAllUsers() en AdminService.
- Se implementó el mapeo de User a UserAdminResponse.
- Se agregó el endpoint GET /admin/users.

### Tests

- Se agregó cobertura para el endpoint de listado de usuarios.
- Se agregaron pruebas de seguridad para acceso ADMIN y USER.
- Se agregaron pruebas de servicio para validar el mapeo de usuarios y roles.

## Resultado

Los administradores pueden obtener el listado completo de usuarios registrados con:

- id
- username
- email
- roles
- enabled

---------

closes #104 