### PR TITLE
feat(admin): Agregar cuando fue registrado un usuario

### DIFF
--- a/src/main/java/com/coworking/admin/dto/UserAdminResponse.java
+++ b/src/main/java/com/coworking/admin/dto/UserAdminResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 
 @Data
@@ -20,4 +21,6 @@ public class UserAdminResponse {
     private Set<String> roles;
 
     private boolean enabled;
+
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
@@ -146,7 +146,8 @@ public class AdminServiceImpl implements AdminService {
                 user.getUsername(),
                 user.getEmail(),
                 roles,
-                user.isEnabled()
+                user.isEnabled(),
+                user.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/coworking/user/model/User.java
+++ b/src/main/java/com/coworking/user/model/User.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -39,5 +40,6 @@ public class User {
     )
 
     private Set<Role> roles = new HashSet<>();
+    private LocalDateTime createdAt;
 
 }

--- a/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -157,7 +158,8 @@ class AdminControllerTest {
                         "dayana",
                         "dayana@gmail.com",
                         Set.of("ROLE_USER"),
-                        true
+                        true,
+                        LocalDateTime.now()
                 );
 
         when(adminService.getAllUsers())

--- a/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.security.PrivateKey;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -101,12 +102,15 @@ class AdminServiceTest {
         Role role = new Role();
         role.setName("ROLE_USER");
 
+        LocalDateTime creationTime = LocalDateTime.now();
+
         User user = new User();
         user.setId(1L);
         user.setUsername("dayana");
         user.setEmail("dayana@gmail.com");
         user.setEnabled(true);
         user.setRoles(Set.of(role));
+        user.setCreatedAt(creationTime);
 
         when(userRepository.findAll())
                 .thenReturn(List.of(user));
@@ -137,6 +141,11 @@ class AdminServiceTest {
         assertTrue(
                 result.getFirst()
                         .isEnabled()
+        );
+
+        assertEquals(
+                creationTime, result.getFirst()
+                        .getCreatedAt()
         );
 
         verify(userRepository).findAll();


### PR DESCRIPTION
En este PR se agrega la fecha de registro a los usuarios.

**Cambios**

- Todos los usuarios devuelven createdAt.
- La fecha corresponde al momento de creación del usuario.
- El endpoint administrativo mantiene compatibilidad con el resto de campos.
- Solo administradores pueden consultar la información.

------
closes #107 