### PR TITLE
Feature/admin user status backend

### DIFF
--- a/src/main/java/com/coworking/admin/controller/AdminController.java
+++ b/src/main/java/com/coworking/admin/controller/AdminController.java
@@ -101,7 +101,7 @@ public class AdminController {
     //                         Update User Status
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     // permite a un administrador actualizar estado de usuario
-    @PatchMapping("/user/{is}/status")
+    @PatchMapping("/users/{id}/status")
     @Operation(summary = "Actualizar estado de usuario", description = "Activa o desactiva una cuenta de usuario")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "Estado actualizado correctamente"),
             @ApiResponse(responseCode = "404", description = "Usuario no encontrado"),

--- a/src/main/java/com/coworking/admin/controller/AdminController.java
+++ b/src/main/java/com/coworking/admin/controller/AdminController.java
@@ -1,9 +1,7 @@
 package com.coworking.admin.controller;
 
 
-import com.coworking.admin.dto.AdminStatsResponse;
-import com.coworking.admin.dto.CreateAdminRequest;
-import com.coworking.admin.dto.UserAdminResponse;
+import com.coworking.admin.dto.*;
 import com.coworking.admin.service.AdminService;
 import com.coworking.dto.common.ApiResponseDto;
 import com.coworking.payment.dto.PaymentResponse;
@@ -27,45 +25,41 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                      Dashboard stats
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     // Devuelve métricas generales para el dashboard administrativo
     @GetMapping("/stats")
-    public ResponseEntity<AdminStatsResponse> getStats(){
-        return  ResponseEntity.ok(
+    public ResponseEntity<AdminStatsResponse> getStats() {
+        return ResponseEntity.ok(
                 adminService.getStats()
         );
     }
 
-    // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                     All reservations
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     // Obtiene todas las reservas registradas en el sistema
     @GetMapping("/reservations")
-    public ResponseEntity<List<ReservationResponse>> getReservations(){
+    public ResponseEntity<List<ReservationResponse>> getReservations() {
         return ResponseEntity.ok(
                 adminService.getAllReservations()
         );
     }
 
-    // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                       All payments
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     // Obtiene todos los pagos registrados
     @GetMapping("/payments")
-    public ResponseEntity<List<PaymentResponse>> getPayments(){
+    public ResponseEntity<List<PaymentResponse>> getPayments() {
         return ResponseEntity.ok(
                 adminService.getAllPayments()
         );
     }
 
-    // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                   Cancel reservation
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     // Permite cancelar una reserva desde el panel administrativo
     @PatchMapping("/reservations/{id}/cancel")
-    public ResponseEntity<ApiResponseDto<String>> cancelReservation(@PathVariable Long id){
+    public ResponseEntity<ApiResponseDto<String>> cancelReservation(@PathVariable Long id) {
         adminService.cancelReservation(id);
 
         return ResponseEntity.ok(
@@ -77,24 +71,20 @@ public class AdminController {
         );
     }
 
-    // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                         All Users
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     // Obtiene todos los usuarios registrados para administración
     @GetMapping("/users")
-    public ResponseEntity<List<UserAdminResponse>> getUsers(){
+    public ResponseEntity<List<UserAdminResponse>> getUsers() {
         return ResponseEntity.ok(
                 adminService.getAllUsers()
         );
     }
 
-    // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     //                         create Admin
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     // Permite a un administrador crear nuevas cuentas administrativas
-    @Operation(
-            summary = "Crear administrador",
-            description = "Permite registrar una nueva cuenta con rol ADMIN"
+    @Operation(summary = "Crear administrador", description = "Permite registrar una nueva cuenta con rol ADMIN"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Administrador creado correctamente"),
@@ -102,9 +92,24 @@ public class AdminController {
             @ApiResponse(responseCode = "403", description = "Acceso denegado")
     })
     @PostMapping("/users/admin")
-    public ResponseEntity<UserAdminResponse> createAdmin(@Valid @RequestBody CreateAdminRequest request){
+    public ResponseEntity<UserAdminResponse> createAdmin(@Valid @RequestBody CreateAdminRequest request) {
         return ResponseEntity.ok(
                 adminService.createAdmin(request)
+        );
+    }
+
+    //                         Update User Status
+    // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+    // permite a un administrador actualizar estado de usuario
+    @PatchMapping("/user/{is}/status")
+    @Operation(summary = "Actualizar estado de usuario", description = "Activa o desactiva una cuenta de usuario")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "Estado actualizado correctamente"),
+            @ApiResponse(responseCode = "404", description = "Usuario no encontrado"),
+            @ApiResponse(responseCode = "400", description = "Solicitud inválida")
+    })
+    public ResponseEntity<UserAdminResponse> updateUserStatus(@PathVariable Long id, @Valid @RequestBody UpdateUserStatusRequest request) {
+        return ResponseEntity.ok(
+                adminService.updateUserStatus(id, request)
         );
     }
 

--- a/src/main/java/com/coworking/admin/dto/UpdateUserStatusRequest.java
+++ b/src/main/java/com/coworking/admin/dto/UpdateUserStatusRequest.java
@@ -1,0 +1,12 @@
+package com.coworking.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateUserStatusRequest {
+    private Boolean enabled;
+}

--- a/src/main/java/com/coworking/admin/service/AdminService.java
+++ b/src/main/java/com/coworking/admin/service/AdminService.java
@@ -1,8 +1,6 @@
 package com.coworking.admin.service;
 
-import com.coworking.admin.dto.AdminStatsResponse;
-import com.coworking.admin.dto.CreateAdminRequest;
-import com.coworking.admin.dto.UserAdminResponse;
+import com.coworking.admin.dto.*;
 import com.coworking.payment.dto.PaymentResponse;
 import com.coworking.reservation.dto.ReservationResponse;
 
@@ -27,4 +25,7 @@ public interface AdminService {
 
     //Crear usuario administrador
     UserAdminResponse createAdmin(CreateAdminRequest request);
+
+    // Actualizar estado de usuario
+    UserAdminResponse updateUserStatus(Long userId, UpdateUserStatusRequest request);
 }

--- a/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
@@ -1,8 +1,6 @@
 package com.coworking.admin.service;
 
-import com.coworking.admin.dto.AdminStatsResponse;
-import com.coworking.admin.dto.CreateAdminRequest;
-import com.coworking.admin.dto.UserAdminResponse;
+import com.coworking.admin.dto.*;
 import com.coworking.exception.BadRequestException;
 import com.coworking.exception.NotFoundException;
 import com.coworking.payment.dto.PaymentResponse;
@@ -141,8 +139,30 @@ public class AdminServiceImpl implements AdminService {
         return mapToUserAdminResponse(savedUser);
     }
 
+    // Actualiza el estado principal de un usuario
+    @Override
+    public UserAdminResponse updateUserStatus(Long userId, UpdateUserStatusRequest request) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() ->
+                        new NotFoundException("Usuario no encontrado")
+                );
+
+        if (request.getEnabled() == null) {
+            throw new BadRequestException("El estado del usuario debe ser true o false");
+        }
+
+        if (user.isEnabled() == request.getEnabled()) {
+            throw new BadRequestException("El usuario ya tiene ese estado");
+        }
+
+        user.setEnabled(request.getEnabled());
+        userRepository.save(user);
+        return mapToUserAdminResponse(user);
+    }
+
     // Obtiene todos los usuarios registrados para la vista administrativa
-    public List<UserAdminResponse> getAllUsers(){
+    public List<UserAdminResponse> getAllUsers() {
         return userRepository.findAll()
                 .stream()
                 .map(this::mapToUserAdminResponse)
@@ -183,7 +203,7 @@ public class AdminServiceImpl implements AdminService {
     }
 
     // Convierte una entidad User a UserAdminResponse
-    private UserAdminResponse mapToUserAdminResponse(User user){
+    private UserAdminResponse mapToUserAdminResponse(User user) {
         Set<String> roles = user.getRoles()
                 .stream()
                 .map(Role::getName)

--- a/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
@@ -3,6 +3,7 @@ package com.coworking.resources.controller.admin;
 import com.coworking.admin.controller.AdminController;
 import com.coworking.admin.dto.AdminStatsResponse;
 import com.coworking.admin.dto.CreateAdminRequest;
+import com.coworking.admin.dto.UpdateUserStatusRequest;
 import com.coworking.admin.dto.UserAdminResponse;
 import com.coworking.admin.service.AdminService;
 import com.coworking.payment.dto.PaymentResponse;
@@ -210,4 +211,40 @@ class AdminControllerTest {
                 .andExpect(jsonPath("$.email")
                         .value("admin@test.com"));
     }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void shouldUpdateUserStatus() throws Exception {
+
+        UpdateUserStatusRequest request =
+                new UpdateUserStatusRequest(false);
+
+        UserAdminResponse response =
+                new UserAdminResponse(
+                        1L,
+                        "dayana",
+                        "dayana@test.com",
+                        Set.of("ROLE_USER"),
+                        false,
+                        LocalDateTime.now()
+                );
+
+        when(adminService.updateUserStatus(
+                eq(1L),
+                any(UpdateUserStatusRequest.class)
+        )).thenReturn(response);
+
+        mockMvc.perform(
+                        patch("/admin/users/1/status")
+                                .with(csrf())
+                                .contentType("application/json")
+                                .content(
+                                        objectMapper.writeValueAsString(request)
+                                )
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled")
+                        .value(false));
+    }
+
 }

--- a/src/test/java/com/coworking/resources/controller/admin/AdminSecurityTest.java
+++ b/src/test/java/com/coworking/resources/controller/admin/AdminSecurityTest.java
@@ -147,4 +147,38 @@ class AdminSecurityTest {
                 )
                 .andExpect(status().isForbidden());
     }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void userShouldNotUpdateUserStatus() throws Exception {
+
+        mockMvc.perform(
+                        patch("/admin/users/1/status")
+                                .with(csrf())
+                                .contentType("application/json")
+                                .content("""
+                                {
+                                  "enabled": false
+                                }
+                                """)
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void adminShouldUpdateUserStatus() throws Exception {
+
+        mockMvc.perform(
+                        patch("/admin/users/1/status")
+                                .with(csrf())
+                                .contentType("application/json")
+                                .content("""
+                                {
+                                  "enabled": false
+                                }
+                                """)
+                )
+                .andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
@@ -2,6 +2,7 @@ package com.coworking.resources.service.admin;
 
 import com.coworking.admin.dto.AdminStatsResponse;
 import com.coworking.admin.dto.CreateAdminRequest;
+import com.coworking.admin.dto.UpdateUserStatusRequest;
 import com.coworking.admin.dto.UserAdminResponse;
 import com.coworking.admin.service.AdminServiceImpl;
 import com.coworking.exception.BadRequestException;
@@ -308,6 +309,103 @@ class AdminServiceTest {
 
         assertEquals(
                 "Rol ADMIN no encontrado",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldEnableUserSuccessfully() {
+
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("dayana");
+        user.setEmail("dayana@test.com");
+        user.setEnabled(false);
+
+        UpdateUserStatusRequest request =
+                new UpdateUserStatusRequest(true);
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.of(user));
+
+        UserAdminResponse response =
+                adminService.updateUserStatus(1L, request);
+
+        assertTrue(response.isEnabled());
+
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void shouldDisableUserSuccessfully() {
+
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("dayana");
+        user.setEmail("dayana@test.com");
+        user.setEnabled(true);
+
+        UpdateUserStatusRequest request =
+                new UpdateUserStatusRequest(false);
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.of(user));
+
+        UserAdminResponse response =
+                adminService.updateUserStatus(1L, request);
+
+        assertFalse(response.isEnabled());
+
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void shouldThrowWhenUserNotFound() {
+
+        UpdateUserStatusRequest request =
+                new UpdateUserStatusRequest(false);
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.empty());
+
+        NotFoundException exception =
+                assertThrows(
+                        NotFoundException.class,
+                        () -> adminService.updateUserStatus(
+                                1L,
+                                request
+                        )
+                );
+
+        assertEquals(
+                "Usuario no encontrado",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldThrowWhenStatusIsNull() {
+
+        User user = new User();
+        user.setId(1L);
+
+        UpdateUserStatusRequest request =
+                new UpdateUserStatusRequest(null);
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.of(user));
+
+        BadRequestException exception =
+                assertThrows(
+                        BadRequestException.class,
+                        () -> adminService.updateUserStatus(
+                                1L,
+                                request
+                        )
+                );
+
+        assertEquals(
+                "El estado del usuario debe ser true o false",
                 exception.getMessage()
         );
     }

--- a/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
@@ -23,7 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.math.BigDecimal;
-import java.security.PrivateKey;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
Se implementa la funcionalidad para activar y desactivar usuarios desde el panel administrativo.

## Cambios realizados

### Backend

* Se agregó el DTO `UpdateUserStatusRequest`.
* Se agregó el método `updateUserStatus()` en `AdminService`.
* Se implementó la lógica de actualización de estado en `AdminServiceImpl`.
* Se agregó el endpoint:

`PATCH /admin/users/{id}/status`

* Se validó:

  * Usuario existente.
  * Estado válido (true/false).

### Testing

Se añadieron pruebas para:

* Activar usuario correctamente.
* Desactivar usuario correctamente.
* Usuario no encontrado.
* Estado inválido.
* Acceso permitido para ADMIN.
* Acceso denegado para USER.

## Resultado

Los administradores pueden activar y desactivar cuentas de usuario desde el panel administrativo y los cambios persisten correctamente en base de datos.

----------
closes #110 
