### PR TITLE
refactor: separar verificación de correo del estado administrativo de usuario

### DIFF
--- a/src/main/java/com/coworking/admin/dto/UserAdminResponse.java
+++ b/src/main/java/com/coworking/admin/dto/UserAdminResponse.java
@@ -22,5 +22,7 @@ public class UserAdminResponse {
 
     private boolean enabled;
 
+    private boolean emailVerified;
+
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
@@ -134,6 +134,7 @@ public class AdminServiceImpl implements AdminService {
         );
         user.setRoles(Set.of(adminRole));
         user.setEnabled(true);
+        user.setEmailVerified(true);
         user.setCreatedAt(LocalDateTime.now());
         User savedUser = userRepository.save(user);
         return mapToUserAdminResponse(savedUser);
@@ -215,6 +216,7 @@ public class AdminServiceImpl implements AdminService {
                 user.getEmail(),
                 roles,
                 user.isEnabled(),
+                user.isEmailVerified(),
                 user.getCreatedAt()
         );
     }

--- a/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
@@ -160,6 +160,7 @@ class AdminControllerTest {
                         "dayana@gmail.com",
                         Set.of("ROLE_USER"),
                         true,
+                        true,
                         LocalDateTime.now()
                 );
 
@@ -190,6 +191,7 @@ class AdminControllerTest {
                         "admin2",
                         "admin@test.com",
                         Set.of("ROLE_ADMIN"),
+                        true,
                         true,
                         LocalDateTime.now()
                 );
@@ -225,6 +227,7 @@ class AdminControllerTest {
                         "dayana",
                         "dayana@test.com",
                         Set.of("ROLE_USER"),
+                        false,
                         false,
                         LocalDateTime.now()
                 );

--- a/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
@@ -120,6 +120,7 @@ class AdminServiceTest {
         user.setUsername("dayana");
         user.setEmail("dayana@gmail.com");
         user.setEnabled(true);
+        user.setEmailVerified(true);
         user.setRoles(Set.of(role));
         user.setCreatedAt(creationTime);
 
@@ -152,6 +153,11 @@ class AdminServiceTest {
         assertTrue(
                 result.getFirst()
                         .isEnabled()
+        );
+
+        assertTrue(
+                result.getFirst()
+                        .isEmailVerified()
         );
 
         assertEquals(
@@ -195,6 +201,7 @@ class AdminServiceTest {
         savedUser.setUsername("admin");
         savedUser.setEmail("admin@test.com");
         savedUser.setEnabled(true);
+        savedUser.setEmailVerified(true);
         savedUser.setRoles(Set.of(adminRole));
         savedUser.setCreatedAt(LocalDateTime.now());
 
@@ -211,6 +218,8 @@ class AdminServiceTest {
                 response.getRoles()
                         .contains("ROLE_ADMIN")
         );
+
+        assertTrue(response.isEmailVerified());
 
         verify(userRepository).save(any(User.class));
     }
@@ -407,5 +416,53 @@ class AdminServiceTest {
                 "El estado del usuario debe ser true o false",
                 exception.getMessage()
         );
+    }
+
+    @Test
+    void shouldMapEmailVerifiedStatus() {
+
+        Role role = new Role();
+        role.setName("ROLE_USER");
+
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("dayana");
+        user.setEmail("dayana@test.com");
+        user.setEnabled(true);
+        user.setEmailVerified(true);
+        user.setRoles(Set.of(role));
+
+        when(userRepository.findAll())
+                .thenReturn(List.of(user));
+
+        List<UserAdminResponse> result =
+                adminService.getAllUsers();
+
+        assertTrue(
+                result.getFirst().isEmailVerified()
+        );
+    }
+
+    @Test
+    void shouldDisableUserWithoutChangingEmailVerification() {
+
+        User user = new User();
+        user.setId(1L);
+        user.setEnabled(true);
+        user.setEmailVerified(true);
+
+        UpdateUserStatusRequest request =
+                new UpdateUserStatusRequest(false);
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.of(user));
+
+        UserAdminResponse response =
+                adminService.updateUserStatus(1L, request);
+
+        assertFalse(response.isEnabled());
+        assertTrue(response.isEmailVerified());
+
+        verify(userRepository).save(user);
     }
 }


### PR DESCRIPTION
En este PR se separó la verificación de correo electrónico del estado administrativo de la cuenta mediante el nuevo campo `emailVerified`.

## Cambios realizados

- Se agregó el campo `emailVerified` a la entidad User.
- Los usuarios registrados se crean con:
  - enabled = true
  - emailVerified = false
- La verificación de correo ahora actualiza únicamente:
  - emailVerified = true
- Se mantuvo el comportamiento actual del login sin modificaciones.
- Se actualizó UserAdminResponse para exponer emailVerified.
- Se actualizaron mappers y pruebas relacionadas.

permitiendo implementar posteriormente la activación y desactivación de usuarios sin afectar el flujo de verificación por correo.

---------------
closes #114 