### PR TITLE
Feature/admin change user role backend

### DIFF
--- a/src/main/java/com/coworking/admin/controller/AdminController.java
+++ b/src/main/java/com/coworking/admin/controller/AdminController.java
@@ -113,4 +113,18 @@ public class AdminController {
         );
     }
 
+    //                         Update User Role
+    // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+    // permite a un administrador actualizar rol de usuario
+    @PatchMapping("/users/{id}/role")
+    @Operation(
+            summary = "Actualizar rol de usuario",
+            description = "Asigna un nuevo rol a un usuario"
+    )
+    public ResponseEntity<UserAdminResponse> updateUserRole(@PathVariable Long id, @Valid @RequestBody UpdateUserRoleRequest request) {
+        return ResponseEntity.ok(
+                adminService.updateUserRole(id, request)
+        );
+    }
+
 }

--- a/src/main/java/com/coworking/admin/dto/UpdateUserRoleRequest.java
+++ b/src/main/java/com/coworking/admin/dto/UpdateUserRoleRequest.java
@@ -1,0 +1,9 @@
+package com.coworking.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateUserRoleRequest(
+        @NotBlank(message = "El rol es obligatorio")
+        String role
+) {
+}

--- a/src/main/java/com/coworking/admin/service/AdminService.java
+++ b/src/main/java/com/coworking/admin/service/AdminService.java
@@ -28,4 +28,7 @@ public interface AdminService {
 
     // Actualizar estado de usuario
     UserAdminResponse updateUserStatus(Long userId, UpdateUserStatusRequest request);
+
+    // Actualizar rol de usuario
+    UserAdminResponse updateUserRole(Long userId, UpdateUserRoleRequest request);
 }

--- a/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
@@ -166,7 +166,7 @@ public class AdminServiceImpl implements AdminService {
             throw new BadRequestException("El usuario ya tiene ese estado");
         }
 
-        if(currentUser.getId().equals(user.getId()) && !request.getEnabled()){
+        if (currentUser.getId().equals(user.getId()) && !request.getEnabled()) {
             throw new BadRequestException(
                     "No puedes desactivar tu propia cuenta"
             );
@@ -175,6 +175,69 @@ public class AdminServiceImpl implements AdminService {
         user.setEnabled(request.getEnabled());
         userRepository.save(user);
         return mapToUserAdminResponse(user);
+    }
+
+    @Override
+    public UserAdminResponse updateUserRole(Long userId, UpdateUserRoleRequest request) {
+        // Buscar usuario
+        User user = userRepository.findById(userId)
+                .orElseThrow(() ->
+                        new NotFoundException("Usuario no encontrado")
+                );
+
+        //validar rol
+        Role newRole = roleRepository.findByName(request.role())
+                .orElseThrow(() ->
+                        new NotFoundException("Rol no encontrado")
+                );
+
+        //obtener rol actual
+        Role currentRole = user.getRoles()
+                .stream()
+                .findFirst()
+                .orElseThrow(() ->
+                        new BadRequestException("Usuario sin rol asignado")
+                );
+
+        //validar que el rol no sea el mismo
+        if (currentRole.getName().equals(newRole.getName())) {
+            throw new BadRequestException("El usuario ya posee ese rol");
+        }
+
+        //Proteger ultimo admin
+        if(currentRole.getName().equals("ROLE_ADMIN")&& newRole.getName().equals("ROLE_USER")){
+            long admins = userRepository.countByRoles_Name("ROLE_ADMIN");
+            if(admins == 1){
+                throw new BadRequestException("No se puede remover el último administrador");
+            }
+        }
+
+        Authentication authentication =
+                SecurityContextHolder.getContext().getAuthentication();
+
+        String currentEmail = authentication.getName();
+
+        User currentUser = userRepository.findByEmail(currentEmail)
+                .orElseThrow(() ->
+                        new NotFoundException(
+                                "Usuario autenticado no encontrado"
+                        )
+                );
+
+        if (
+                currentUser.getId().equals(user.getId())
+                        && currentRole.getName().equals("ROLE_ADMIN")
+                        && newRole.getName().equals("ROLE_USER")
+        ) {
+            throw new BadRequestException(
+                    "No puedes remover tus propios privilegios administrativos"
+            );
+        }
+
+        user.setRoles(Set.of(newRole));
+        userRepository.save(user);
+        return mapToUserAdminResponse(user);
+
     }
 
     // Obtiene todos los usuarios registrados para la vista administrativa

--- a/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
@@ -234,7 +234,9 @@ public class AdminServiceImpl implements AdminService {
             );
         }
 
-        user.setRoles(Set.of(newRole));
+        // El sistema permite un único rol por usuario.
+        user.getRoles().clear();
+        user.getRoles().add(newRole);
         userRepository.save(user);
         return mapToUserAdminResponse(user);
 

--- a/src/main/java/com/coworking/user/repository/UserRepository.java
+++ b/src/main/java/com/coworking/user/repository/UserRepository.java
@@ -13,4 +13,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
     boolean existsByUsername(String username);
+    long countByRoles_Name(String roleName);
 }

--- a/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
@@ -1,10 +1,7 @@
 package com.coworking.resources.controller.admin;
 
 import com.coworking.admin.controller.AdminController;
-import com.coworking.admin.dto.AdminStatsResponse;
-import com.coworking.admin.dto.CreateAdminRequest;
-import com.coworking.admin.dto.UpdateUserStatusRequest;
-import com.coworking.admin.dto.UserAdminResponse;
+import com.coworking.admin.dto.*;
 import com.coworking.admin.service.AdminService;
 import com.coworking.payment.dto.PaymentResponse;
 import com.coworking.payment.enums.PaymentStatus;
@@ -248,6 +245,42 @@ class AdminControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.enabled")
                         .value(false));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void shouldUpdateUserRole() throws Exception {
+
+        UpdateUserRoleRequest request =
+                new UpdateUserRoleRequest("ROLE_ADMIN");
+
+        UserAdminResponse response =
+                new UserAdminResponse(
+                        1L,
+                        "dayana",
+                        "dayana@test.com",
+                        Set.of("ROLE_ADMIN"),
+                        true,
+                        true,
+                        LocalDateTime.now()
+                );
+
+        when(adminService.updateUserRole(
+                eq(1L),
+                any(UpdateUserRoleRequest.class)
+        )).thenReturn(response);
+
+        mockMvc.perform(
+                        patch("/admin/users/1/role")
+                                .with(csrf())
+                                .contentType("application/json")
+                                .content(
+                                        objectMapper.writeValueAsString(request)
+                                )
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roles[0]")
+                        .value("ROLE_ADMIN"));
     }
 
 }

--- a/src/test/java/com/coworking/resources/controller/admin/AdminSecurityTest.java
+++ b/src/test/java/com/coworking/resources/controller/admin/AdminSecurityTest.java
@@ -181,4 +181,38 @@ class AdminSecurityTest {
                 )
                 .andExpect(status().isOk());
     }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void userShouldNotUpdateUserRole() throws Exception {
+
+        mockMvc.perform(
+                        patch("/admin/users/1/role")
+                                .with(csrf())
+                                .contentType("application/json")
+                                .content("""
+                            {
+                              "role":"ROLE_ADMIN"
+                            }
+                            """)
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void adminShouldUpdateUserRole() throws Exception {
+
+        mockMvc.perform(
+                        patch("/admin/users/1/role")
+                                .with(csrf())
+                                .contentType("application/json")
+                                .content("""
+                            {
+                              "role":"ROLE_ADMIN"
+                            }
+                            """)
+                )
+                .andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
@@ -1,9 +1,6 @@
 package com.coworking.resources.service.admin;
 
-import com.coworking.admin.dto.AdminStatsResponse;
-import com.coworking.admin.dto.CreateAdminRequest;
-import com.coworking.admin.dto.UpdateUserStatusRequest;
-import com.coworking.admin.dto.UserAdminResponse;
+import com.coworking.admin.dto.*;
 import com.coworking.admin.service.AdminServiceImpl;
 import com.coworking.exception.BadRequestException;
 import com.coworking.exception.NotFoundException;
@@ -15,6 +12,7 @@ import com.coworking.role.model.Role;
 import com.coworking.role.repository.RoleRepository;
 import com.coworking.user.model.User;
 import com.coworking.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -55,6 +53,31 @@ class AdminServiceTest {
 
     @InjectMocks
     private AdminServiceImpl adminService;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void mockAuthenticatedUser(User user) {
+
+        when(userRepository.findByEmail(user.getEmail()))
+                .thenReturn(Optional.of(user));
+
+        Authentication authentication =
+                mock(Authentication.class);
+
+        when(authentication.getName())
+                .thenReturn(user.getEmail());
+
+        SecurityContext securityContext =
+                mock(SecurityContext.class);
+
+        when(securityContext.getAuthentication())
+                .thenReturn(authentication);
+
+        SecurityContextHolder.setContext(securityContext);
+    }
 
     @Test
     void shouldReturnAdminStats() {
@@ -326,11 +349,16 @@ class AdminServiceTest {
     @Test
     void shouldEnableUserSuccessfully() {
 
+        Role role = new Role();
+        role.setName("ROLE_USER");
+
         User user = new User();
         user.setId(1L);
         user.setUsername("dayana");
         user.setEmail("dayana@test.com");
         user.setEnabled(false);
+        user.setEmailVerified(true);
+        user.setRoles(Set.of(role));
 
         UpdateUserStatusRequest request =
                 new UpdateUserStatusRequest(true);
@@ -338,10 +366,16 @@ class AdminServiceTest {
         when(userRepository.findById(1L))
                 .thenReturn(Optional.of(user));
 
+        User currentAdmin = new User();
+        currentAdmin.setId(99L);
+        currentAdmin.setEmail("admin@test.com");
+        mockAuthenticatedUser(currentAdmin);
+
         UserAdminResponse response =
                 adminService.updateUserStatus(1L, request);
 
         assertTrue(response.isEnabled());
+        assertTrue(response.isEmailVerified());
 
         verify(userRepository).save(user);
     }
@@ -349,11 +383,16 @@ class AdminServiceTest {
     @Test
     void shouldDisableUserSuccessfully() {
 
+        Role role = new Role();
+        role.setName("ROLE_USER");
+
         User user = new User();
         user.setId(1L);
         user.setUsername("dayana");
         user.setEmail("dayana@test.com");
         user.setEnabled(true);
+        user.setEmailVerified(true);
+        user.setRoles(Set.of(role));
 
         UpdateUserStatusRequest request =
                 new UpdateUserStatusRequest(false);
@@ -361,10 +400,16 @@ class AdminServiceTest {
         when(userRepository.findById(1L))
                 .thenReturn(Optional.of(user));
 
+        User currentAdmin = new User();
+        currentAdmin.setId(99L);
+        currentAdmin.setEmail("admin@test.com");
+        mockAuthenticatedUser(currentAdmin);
+
         UserAdminResponse response =
                 adminService.updateUserStatus(1L, request);
 
         assertFalse(response.isEnabled());
+        assertTrue(response.isEmailVerified());
 
         verify(userRepository).save(user);
     }
@@ -448,16 +493,27 @@ class AdminServiceTest {
     @Test
     void shouldDisableUserWithoutChangingEmailVerification() {
 
+        Role role = new Role();
+        role.setName("ROLE_USER");
+
         User user = new User();
         user.setId(1L);
+        user.setUsername("dayana");
+        user.setEmail("dayana@test.com");
         user.setEnabled(true);
         user.setEmailVerified(true);
+        user.setRoles(Set.of(role));
 
         UpdateUserStatusRequest request =
                 new UpdateUserStatusRequest(false);
 
         when(userRepository.findById(1L))
                 .thenReturn(Optional.of(user));
+
+        User currentAdmin = new User();
+        currentAdmin.setId(99L);
+        currentAdmin.setEmail("admin@test.com");
+        mockAuthenticatedUser(currentAdmin);
 
         UserAdminResponse response =
                 adminService.updateUserStatus(1L, request);
@@ -511,6 +567,251 @@ class AdminServiceTest {
 
         assertEquals(
                 "No puedes desactivar tu propia cuenta",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldUpdateUserRoleSuccessfully() {
+
+        Role userRole = new Role();
+        userRole.setName("ROLE_USER");
+
+        Role adminRole = new Role();
+        adminRole.setName("ROLE_ADMIN");
+
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("dayana");
+        user.setEmail("dayana@test.com");
+        user.setRoles(Set.of(userRole));
+
+        UpdateUserRoleRequest request =
+                new UpdateUserRoleRequest("ROLE_ADMIN");
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.of(user));
+
+        when(roleRepository.findByName("ROLE_ADMIN"))
+                .thenReturn(Optional.of(adminRole));
+
+        User currentAdmin = new User();
+        currentAdmin.setId(99L);
+        currentAdmin.setEmail("admin@test.com");
+
+        when(userRepository.findByEmail("admin@test.com"))
+                .thenReturn(Optional.of(currentAdmin));
+
+        Authentication authentication =
+                mock(Authentication.class);
+
+        when(authentication.getName())
+                .thenReturn("admin@test.com");
+
+        SecurityContext securityContext =
+                mock(SecurityContext.class);
+
+        when(securityContext.getAuthentication())
+                .thenReturn(authentication);
+
+        SecurityContextHolder.setContext(securityContext);
+
+        UserAdminResponse response =
+                adminService.updateUserRole(1L, request);
+
+        assertTrue(
+                response.getRoles().contains("ROLE_ADMIN")
+        );
+
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void shouldThrowWhenChangingRoleAndUserNotFound() {
+
+        UpdateUserRoleRequest request =
+                new UpdateUserRoleRequest("ROLE_ADMIN");
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.empty());
+
+        NotFoundException exception =
+                assertThrows(
+                        NotFoundException.class,
+                        () -> adminService.updateUserRole(
+                                1L,
+                                request
+                        )
+                );
+
+        assertEquals(
+                "Usuario no encontrado",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldThrowWhenRoleDoesNotExist() {
+
+        Role userRole = new Role();
+        userRole.setName("ROLE_USER");
+
+        User user = new User();
+        user.setId(1L);
+        user.setRoles(Set.of(userRole));
+
+        UpdateUserRoleRequest request =
+                new UpdateUserRoleRequest("ROLE_ADMIN");
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.of(user));
+
+        when(roleRepository.findByName("ROLE_ADMIN"))
+                .thenReturn(Optional.empty());
+
+        NotFoundException exception =
+                assertThrows(
+                        NotFoundException.class,
+                        () -> adminService.updateUserRole(
+                                1L,
+                                request
+                        )
+                );
+
+        assertEquals(
+                "Rol no encontrado",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldThrowWhenUserAlreadyHasRole() {
+
+        Role role = new Role();
+        role.setName("ROLE_USER");
+
+        User user = new User();
+        user.setId(1L);
+        user.setRoles(Set.of(role));
+
+        UpdateUserRoleRequest request =
+                new UpdateUserRoleRequest("ROLE_USER");
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.of(user));
+
+        when(roleRepository.findByName("ROLE_USER"))
+                .thenReturn(Optional.of(role));
+
+        BadRequestException exception =
+                assertThrows(
+                        BadRequestException.class,
+                        () -> adminService.updateUserRole(
+                                1L,
+                                request
+                        )
+                );
+
+        assertEquals(
+                "El usuario ya posee ese rol",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldThrowWhenRemovingLastAdmin() {
+
+        Role adminRole = new Role();
+        adminRole.setName("ROLE_ADMIN");
+
+        Role userRole = new Role();
+        userRole.setName("ROLE_USER");
+
+        User user = new User();
+        user.setId(1L);
+        user.setRoles(Set.of(adminRole));
+
+        UpdateUserRoleRequest request =
+                new UpdateUserRoleRequest("ROLE_USER");
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.of(user));
+
+        when(roleRepository.findByName("ROLE_USER"))
+                .thenReturn(Optional.of(userRole));
+
+        when(userRepository.countByRoles_Name("ROLE_ADMIN"))
+                .thenReturn(1L);
+
+        BadRequestException exception =
+                assertThrows(
+                        BadRequestException.class,
+                        () -> adminService.updateUserRole(
+                                1L,
+                                request
+                        )
+                );
+
+        assertEquals(
+                "No se puede remover el último administrador",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldThrowWhenAdminRemovesOwnPrivileges() {
+
+        Role adminRole = new Role();
+        adminRole.setName("ROLE_ADMIN");
+
+        Role userRole = new Role();
+        userRole.setName("ROLE_USER");
+
+        User admin = new User();
+        admin.setId(1L);
+        admin.setEmail("admin@test.com");
+        admin.setRoles(Set.of(adminRole));
+
+        UpdateUserRoleRequest request =
+                new UpdateUserRoleRequest("ROLE_USER");
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.of(admin));
+
+        when(roleRepository.findByName("ROLE_USER"))
+                .thenReturn(Optional.of(userRole));
+
+        when(userRepository.countByRoles_Name("ROLE_ADMIN"))
+                .thenReturn(2L);
+
+        when(userRepository.findByEmail("admin@test.com"))
+                .thenReturn(Optional.of(admin));
+
+        Authentication authentication =
+                mock(Authentication.class);
+
+        when(authentication.getName())
+                .thenReturn("admin@test.com");
+
+        SecurityContext securityContext =
+                mock(SecurityContext.class);
+
+        when(securityContext.getAuthentication())
+                .thenReturn(authentication);
+
+        SecurityContextHolder.setContext(securityContext);
+
+        BadRequestException exception =
+                assertThrows(
+                        BadRequestException.class,
+                        () -> adminService.updateUserRole(
+                                1L,
+                                request
+                        )
+                );
+
+        assertEquals(
+                "No puedes remover tus propios privilegios administrativos",
                 exception.getMessage()
         );
     }


### PR DESCRIPTION
En este PR se implementó la funcionalidad para que un administrador pueda cambiar el rol de un usuario desde el panel administrativo.

La solución permite promover usuarios a administradores o remover privilegios administrativos, aplicando las validaciones de negocio necesarias para mantener la integridad del sistema.

## Cambios realizados

Se agregó el endpoint:

```http
PATCH /admin/users/{id}/role
```
Se creó:

* `UpdateUserRoleRequest`

para recibir el nuevo rol solicitado.

#### Servicio administrativo

Se implementó la lógica de cambio de rol en `AdminServiceImpl`.

Validaciones incluidas:

* Verificar que el usuario exista.
* Verificar que el rol exista.
* Impedir asignar el mismo rol que ya posee el usuario.
* Impedir remover el último administrador del sistema.
* Impedir que un administrador elimine sus propios privilegios administrativos.
* Retornar la información actualizada del usuario.

#### Repositorio

Se agregó el método:

```java
long countByRoles_Name(String roleName);
```

para validar la existencia de otros administradores activos antes de realizar una degradación de rol.

---

## Pruebas agregadas

Se agregaron pruebas para:

* Cambio exitoso de rol.
* Usuario inexistente.
* Rol inexistente.
* Intento de asignar el mismo rol.
* Protección del último administrador.
* Protección contra auto-remoción de privilegios administrativos.
* Actualización exitosa de rol mediante el endpoint administrativo.
* Denegar acceso a usuarios sin rol ADMIN.
* Permitir acceso a administradores para actualizar roles.

---
closes #120
