### PR TITLE
fix(payment): guardar método de pago en pagos de Stripe

### DIFF
--- a/src/main/java/com/coworking/payment/service/StripePaymentService.java
+++ b/src/main/java/com/coworking/payment/service/StripePaymentService.java
@@ -40,7 +40,7 @@ public class StripePaymentService implements PaymentService {
                 .amount(payment.getAmount())
                 .currency(payment.getCurrency())
                 .status(payment.getStatus())
-                .paymentMethod("stripe")
+                .paymentMethod(payment.getPaymentMethod())
                 .paidAt(payment.getPaidAt())
                 .build();
     }
@@ -121,6 +121,7 @@ public class StripePaymentService implements PaymentService {
         payment.setPaidAt(Instant.now());
 
         payment.setStatus(PaymentStatus.SUCCEEDED);
+        payment.setPaymentMethod(paymentIntent.getPaymentMethod());
         paymentRepository.save(payment);
         reservation.setStatus(ReservationStatus.PAID);
         reservationRepository.save(reservation);


### PR DESCRIPTION
Este Pull Request corrige el registro de pagos exitosos realizados mediante Stripe, asegurando que el método de pago se almacene antes de persistir la entidad `Payment`.

## Cambios realizados

* Se asigna valor  al campo `paymentMethod` al registrar un pago exitoso.
* Se modifica la respuesta de la API para devolver el método de pago almacenado en la base de datos en lugar de un valor fijo.

## Problema

El webhook de Stripe fallaba al procesar el evento `payment_intent.succeeded` debido a que la columna `payment_method` está definida como `NOT NULL`, pero no se asignaba ningún valor antes de guardar el pago.

## Resultado

* Los pagos exitosos de Stripe se registran correctamente en la base de datos.
* El webhook deja de fallar por la restricción `NOT NULL` de la columna `payment_method`.
* La API devuelve el método de pago realmente almacenado para cada pago.
