### PR TITLE
feat/Crear endpoint para obtener perfil del usuario autenticado

### DIFF
--- a/src/main/java/com/coworking/admin/controller/AdminController.java
+++ b/src/main/java/com/coworking/admin/controller/AdminController.java
@@ -127,4 +127,14 @@ public class AdminController {
         );
     }
 
+    //                         Get Profile
+    // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+    // Perfil autenticado
+    @GetMapping("/profile")
+    public ResponseEntity<AdminProfileResponse> getProfile() {
+        return ResponseEntity.ok(
+                adminService.getProfile()
+        );
+    }
+
 }

--- a/src/main/java/com/coworking/admin/dto/AdminProfileResponse.java
+++ b/src/main/java/com/coworking/admin/dto/AdminProfileResponse.java
@@ -1,0 +1,11 @@
+package com.coworking.admin.dto;
+
+import java.util.Set;
+
+public record AdminProfileResponse(
+        Long id,
+        String username,
+        String email,
+        Set<String> roles
+) {
+}

--- a/src/main/java/com/coworking/admin/service/AdminService.java
+++ b/src/main/java/com/coworking/admin/service/AdminService.java
@@ -31,4 +31,7 @@ public interface AdminService {
 
     // Actualizar rol de usuario
     UserAdminResponse updateUserRole(Long userId, UpdateUserRoleRequest request);
+
+    // Perfil autenticado
+    AdminProfileResponse getProfile();
 }

--- a/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
@@ -205,9 +205,9 @@ public class AdminServiceImpl implements AdminService {
         }
 
         //Proteger ultimo admin
-        if(currentRole.getName().equals("ROLE_ADMIN")&& newRole.getName().equals("ROLE_USER")){
+        if (currentRole.getName().equals("ROLE_ADMIN") && newRole.getName().equals("ROLE_USER")) {
             long admins = userRepository.countByRoles_Name("ROLE_ADMIN");
-            if(admins == 1){
+            if (admins == 1) {
                 throw new BadRequestException("No se puede remover el último administrador");
             }
         }
@@ -240,6 +240,29 @@ public class AdminServiceImpl implements AdminService {
         userRepository.save(user);
         return mapToUserAdminResponse(user);
 
+    }
+
+    //Usuario para perfil autenticado
+    @Override
+    public AdminProfileResponse getProfile() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        String email = authentication.getName();
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() ->
+                        new NotFoundException("Usuario autenticado no encontrado")
+                );
+
+        return new AdminProfileResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getEmail(),
+                user.getRoles()
+                        .stream()
+                        .map(r -> r.getName())
+                        .collect(Collectors.toSet())
+        );
     }
 
     // Obtiene todos los usuarios registrados para la vista administrativa


### PR DESCRIPTION
En este Pr se crea un endpoint que permita obtener la información básica del usuario autenticado desde el panel administrativo.

## Cambios realizados

- Se creó el DTO `AdminProfileResponse`.
- Se agregó el método `getProfile()` en `AdminService`.
- Se implementó la lógica de obtención del usuario autenticado en `AdminServiceImpl`.
- Se expuso el endpoint `GET /admin/profile`.
- Se reutilizó la autenticación basada en JWT y `SecurityContextHolder`.

## Endpoint

GET /admin/profile

### Respuesta

```json
{
  "id": 2,
  "username": "admin",
  "email": "admin@coworking.com",
  "roles": ["ROLE_ADMIN"]
}
 ```
-----
closes #123 
