### PR TITLE
feat(admin): implementar paginación en tablas administrativas

### DIFF
--- a/src/main/java/com/coworking/admin/controller/AdminController.java
+++ b/src/main/java/com/coworking/admin/controller/AdminController.java
@@ -39,9 +39,12 @@ public class AdminController {
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     // Obtiene todas las reservas registradas en el sistema
     @GetMapping("/reservations")
-    public ResponseEntity<List<ReservationResponse>> getReservations() {
+    public ResponseEntity<AdminPageResponse<ReservationResponse>> getReservations(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
         return ResponseEntity.ok(
-                adminService.getAllReservations()
+                adminService.getReservations(page, size)
         );
     }
 
@@ -49,9 +52,12 @@ public class AdminController {
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     // Obtiene todos los pagos registrados
     @GetMapping("/payments")
-    public ResponseEntity<List<PaymentResponse>> getPayments() {
+    public ResponseEntity<AdminPageResponse<PaymentResponse>> getPayments(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
         return ResponseEntity.ok(
-                adminService.getAllPayments()
+                adminService.getPayments(page, size)
         );
     }
 
@@ -75,9 +81,12 @@ public class AdminController {
     // . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     // Obtiene todos los usuarios registrados para administración
     @GetMapping("/users")
-    public ResponseEntity<List<UserAdminResponse>> getUsers() {
+    public ResponseEntity<AdminPageResponse<UserAdminResponse>> getUsers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
         return ResponseEntity.ok(
-                adminService.getAllUsers()
+                adminService.getUsers(page, size)
         );
     }
 

--- a/src/main/java/com/coworking/admin/dto/AdminPageResponse.java
+++ b/src/main/java/com/coworking/admin/dto/AdminPageResponse.java
@@ -1,0 +1,17 @@
+package com.coworking.admin.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record AdminPageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        long totalPages,
+        boolean first,
+        boolean last
+) {
+}

--- a/src/main/java/com/coworking/admin/service/AdminService.java
+++ b/src/main/java/com/coworking/admin/service/AdminService.java
@@ -12,13 +12,22 @@ public interface AdminService {
     AdminStatsResponse getStats();
 
     // Reservas
-    List<ReservationResponse> getAllReservations();
+    AdminPageResponse<ReservationResponse> getReservations(
+            int page,
+            int size
+    );
 
     // Pagos
-    List<PaymentResponse> getAllPayments();
+    AdminPageResponse<PaymentResponse> getPayments(
+            int page,
+            int size
+    );
 
     // Usuarios
-    List<UserAdminResponse> getAllUsers();
+    AdminPageResponse<UserAdminResponse> getUsers(
+            int page,
+            int size
+    );
 
     // Administración de reservas
     void cancelReservation(Long reservationId);

--- a/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/coworking/admin/service/AdminServiceImpl.java
@@ -15,6 +15,8 @@ import com.coworking.role.repository.RoleRepository;
 import com.coworking.user.model.User;
 import com.coworking.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,22 +70,50 @@ public class AdminServiceImpl implements AdminService {
 
     // Obtiene todas las reservas y las transforma a DTO de respuesta
     @Override
-    public List<ReservationResponse> getAllReservations() {
+    public AdminPageResponse<ReservationResponse> getReservations(int page, int size) {
 
-        return reservationRepository.findAll()
-                .stream()
-                .map(this::mapReservationToResponse)
-                .toList();
+        Pageable pageable = PageRequest.of(page, size,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        Page<ReservationResponse> reservations =
+                reservationRepository
+                        .findAll(pageable)
+                        .map(this::mapReservationToResponse);
+
+        return AdminPageResponse.<ReservationResponse>builder()
+                .content(reservations.getContent())
+                .page(reservations.getNumber())
+                .size(reservations.getSize())
+                .totalElements(reservations.getTotalElements())
+                .totalPages(reservations.getTotalPages())
+                .first(reservations.isFirst())
+                .last(reservations.isLast())
+                .build();
     }
 
     // Obtiene todos los pagos y los transforma a DTO de respuesta
     @Override
-    public List<PaymentResponse> getAllPayments() {
+    public AdminPageResponse<PaymentResponse> getPayments(int page, int size) {
 
-        return paymentRepository.findAll()
-                .stream()
-                .map(this::mapPaymentToResponse)
-                .toList();
+        Pageable pageable = PageRequest.of(page, size,
+                Sort.by(Sort.Direction.DESC, "paidAt")
+        );
+
+        Page<PaymentResponse> payments =
+                paymentRepository
+                        .findAll(pageable)
+                        .map(this::mapPaymentToResponse);
+
+        return AdminPageResponse.<PaymentResponse>builder()
+                .content(payments.getContent())
+                .page(payments.getNumber())
+                .size(payments.getSize())
+                .totalElements(payments.getTotalElements())
+                .totalPages(payments.getTotalPages())
+                .first(payments.isFirst())
+                .last(payments.isLast())
+                .build();
     }
 
     // Cancela una reserva independientemente de su propietario
@@ -266,11 +296,27 @@ public class AdminServiceImpl implements AdminService {
     }
 
     // Obtiene todos los usuarios registrados para la vista administrativa
-    public List<UserAdminResponse> getAllUsers() {
-        return userRepository.findAll()
-                .stream()
-                .map(this::mapToUserAdminResponse)
-                .toList();
+    @Override
+    public AdminPageResponse<UserAdminResponse> getUsers(int page, int size) {
+
+        Pageable pageable = PageRequest.of(page, size,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        Page<UserAdminResponse> users =
+                userRepository
+                        .findAll(pageable)
+                        .map(this::mapToUserAdminResponse);
+
+        return AdminPageResponse.<UserAdminResponse>builder()
+                .content(users.getContent())
+                .page(users.getNumber())
+                .size(users.getSize())
+                .totalElements(users.getTotalElements())
+                .totalPages(users.getTotalPages())
+                .first(users.isFirst())
+                .last(users.isLast())
+                .build();
     }
 
     // MAPPERS

--- a/src/main/java/com/coworking/room/controller/RoomController.java
+++ b/src/main/java/com/coworking/room/controller/RoomController.java
@@ -1,5 +1,6 @@
 package com.coworking.room.controller;
 
+import com.coworking.admin.dto.AdminPageResponse;
 import com.coworking.room.dto.RoomAvailabilityResponse;
 import com.coworking.room.dto.RoomDto;
 import com.coworking.room.service.RoomService;
@@ -26,8 +27,13 @@ public class RoomController {
     // listar
     @GetMapping
     @Operation(summary = "Listar todas las salas")
-    public List<RoomDto> getAllRoom(){
-        return roomService.getAllRooms();
+    public ResponseEntity<AdminPageResponse<RoomDto>> getAllRoom(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        return ResponseEntity.ok(
+                roomService.getAllRooms(page, size)
+        );
     }
 
     //buscar por id

--- a/src/main/java/com/coworking/room/service/RoomService.java
+++ b/src/main/java/com/coworking/room/service/RoomService.java
@@ -1,5 +1,6 @@
 package com.coworking.room.service;
 
+import com.coworking.admin.dto.AdminPageResponse;
 import com.coworking.exception.RoomHasReservationsException;
 import com.coworking.room.dto.RoomAvailabilityResponse;
 import com.coworking.room.dto.RoomDto;
@@ -10,6 +11,9 @@ import com.coworking.room.repository.RoomRepository;
 import com.coworking.storage.service.StorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +34,7 @@ public class RoomService {
     private final StorageService storageService;
     // MAPPERS
 
-    private RoomDto mapToDto(Room room){
+    private RoomDto mapToDto(Room room) {
         RoomDto dto = new RoomDto();
         dto.setId(room.getId());
         dto.setName(room.getName());
@@ -44,7 +48,7 @@ public class RoomService {
         return dto;
     }
 
-    private Room mapToEntity(RoomDto dto){
+    private Room mapToEntity(RoomDto dto) {
         Room room = new Room();
         room.setId(dto.getId());
         room.setName(dto.getName());
@@ -58,7 +62,7 @@ public class RoomService {
         return room;
     }
 
-    private RoomAvailabilityResponse mapToAvailability(Room room, boolean available){
+    private RoomAvailabilityResponse mapToAvailability(Room room, boolean available) {
 
         RoomAvailabilityResponse dto = new RoomAvailabilityResponse();
 
@@ -75,16 +79,31 @@ public class RoomService {
 
     // CRUD ROOMS
 
-    public List<RoomDto> getAllRooms(){
+    public AdminPageResponse<RoomDto> getAllRooms(int page, int size) {
 
-        return roomRepository
-                .findAll(Sort.by(Sort.Direction.ASC,"capacity"))
-                .stream()
-                .map(this::mapToDto)
-                .toList();
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Direction.ASC, "capacity")
+        );
+
+        Page<RoomDto> rooms =
+                roomRepository
+                        .findAll(pageable)
+                        .map(this::mapToDto);
+
+        return AdminPageResponse.<RoomDto>builder()
+                .content(rooms.getContent())
+                .page(rooms.getNumber())
+                .size(rooms.getSize())
+                .totalElements(rooms.getTotalElements())
+                .totalPages(rooms.getTotalPages())
+                .first(rooms.isFirst())
+                .last(rooms.isLast())
+                .build();
     }
 
-    public Optional<RoomDto> getRoomById(Long id){
+    public Optional<RoomDto> getRoomById(Long id) {
 
         return roomRepository
                 .findById(id)
@@ -92,11 +111,11 @@ public class RoomService {
     }
 
     @Transactional
-    public RoomDto createRoom(RoomDto dto, MultipartFile image){
+    public RoomDto createRoom(RoomDto dto, MultipartFile image) {
 
         Room room = mapToEntity(dto);
 
-        if(image != null && !image.isEmpty()){
+        if (image != null && !image.isEmpty()) {
             String imageUrl = storageService.upload(image);
             room.setImageUrl(imageUrl);
         }
@@ -104,7 +123,7 @@ public class RoomService {
         return mapToDto(roomRepository.save(room));
     }
 
-    public Optional<RoomDto> updateRoom(Long id, RoomDto dto, MultipartFile image){
+    public Optional<RoomDto> updateRoom(Long id, RoomDto dto, MultipartFile image) {
 
         return roomRepository.findById(id).map(room -> {
 
@@ -126,9 +145,9 @@ public class RoomService {
     }
 
     @Transactional
-    public boolean deleteRoom(Long id){
+    public boolean deleteRoom(Long id) {
 
-        if(!roomRepository.existsById(id)) {
+        if (!roomRepository.existsById(id)) {
             return false;
         }
 
@@ -146,16 +165,16 @@ public class RoomService {
 
     public List<RoomAvailabilityResponse> getRoomsAvailability(
             Instant start,
-           Instant end,
+            Instant end,
             Integer people
-    ){
+    ) {
 
         List<Room> rooms =
                 roomRepository.findByCapacityOrderByCapacityAsc(people);
 
         List<Reservation> overlapping =
                 reservationRepository
-                        .findByStartAtLessThanAndEndAtGreaterThan(end,start);
+                        .findByStartAtLessThanAndEndAtGreaterThan(end, start);
 
         Set<Long> busyRoomIds =
                 overlapping.stream()

--- a/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/admin/AdminControllerTest.java
@@ -89,7 +89,7 @@ class AdminControllerTest {
 
     @Test
     @WithMockUser(roles = "ADMIN")
-    void shouldReturnAllReservations() throws Exception {
+    void shouldReturnPagedReservations() throws Exception {
 
         ReservationResponse reservation = new ReservationResponse();
 
@@ -98,18 +98,33 @@ class AdminControllerTest {
         reservation.setUsername("dayana");
         reservation.setStatus(ReservationStatus.PAID);
 
-        when(adminService.getAllReservations())
-                .thenReturn(List.of(reservation));
+        AdminPageResponse<ReservationResponse> response =
+                AdminPageResponse.<ReservationResponse>builder()
+                        .content(List.of(reservation))
+                        .page(0)
+                        .size(10)
+                        .totalElements(1)
+                        .totalPages(1)
+                        .first(true)
+                        .last(true)
+                        .build();
 
-        mockMvc.perform(get("/admin/reservations"))
+        when(adminService.getReservations(0, 10))
+                .thenReturn(response);
+
+        mockMvc.perform(
+                        get("/admin/reservations")
+                                .param("page", "0")
+                                .param("size", "10")
+                )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].roomName")
+                .andExpect(jsonPath("$.content[0].roomName")
                         .value("Sala Privada"));
     }
 
     @Test
     @WithMockUser(roles = "ADMIN")
-    void shouldReturnAllPayments() throws Exception {
+    void shouldReturnPagedPayments() throws Exception {
 
         PaymentResponse payment = PaymentResponse.builder()
                 .id(1L)
@@ -121,12 +136,27 @@ class AdminControllerTest {
                 .paidAt(Instant.now())
                 .build();
 
-        when(adminService.getAllPayments())
-                .thenReturn(List.of(payment));
+        AdminPageResponse<PaymentResponse> response =
+                AdminPageResponse.<PaymentResponse>builder()
+                        .content(List.of(payment))
+                        .page(0)
+                        .size(10)
+                        .totalElements(1)
+                        .totalPages(1)
+                        .first(true)
+                        .last(true)
+                        .build();
 
-        mockMvc.perform(get("/admin/payments"))
+        when(adminService.getPayments(0, 10))
+                .thenReturn(response);
+
+        mockMvc.perform(
+                        get("/admin/payments")
+                                .param("page", "0")
+                                .param("size", "10")
+                )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].roomName")
+                .andExpect(jsonPath("$.content[0].roomName")
                         .value("Sala Premium"));
     }
 
@@ -149,7 +179,8 @@ class AdminControllerTest {
 
     @Test
     @WithMockUser(roles = "ADMIN")
-    void shouldReturnAllUsers() throws Exception {
+    void shouldReturnPagedUsers() throws Exception {
+
         UserAdminResponse user =
                 new UserAdminResponse(
                         1L,
@@ -161,14 +192,29 @@ class AdminControllerTest {
                         LocalDateTime.now()
                 );
 
-        when(adminService.getAllUsers())
-                .thenReturn(List.of(user));
+        AdminPageResponse<UserAdminResponse> response =
+                AdminPageResponse.<UserAdminResponse>builder()
+                        .content(List.of(user))
+                        .page(0)
+                        .size(10)
+                        .totalElements(1)
+                        .totalPages(1)
+                        .first(true)
+                        .last(true)
+                        .build();
 
-        mockMvc.perform(get("/admin/users"))
+        when(adminService.getUsers(0, 10))
+                .thenReturn(response);
+
+        mockMvc.perform(
+                        get("/admin/users")
+                                .param("page", "0")
+                                .param("size", "10")
+                )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].username")
+                .andExpect(jsonPath("$.content[0].username")
                         .value("dayana"))
-                .andExpect(jsonPath("$[0].email")
+                .andExpect(jsonPath("$.content[0].email")
                         .value("dayana@gmail.com"));
     }
 

--- a/src/test/java/com/coworking/resources/controller/room/RoomControllerTest.java
+++ b/src/test/java/com/coworking/resources/controller/room/RoomControllerTest.java
@@ -1,5 +1,6 @@
 package com.coworking.resources.controller.room;
 
+import com.coworking.admin.dto.AdminPageResponse;
 import com.coworking.room.controller.RoomController;
 import com.coworking.room.dto.RoomDto;
 import com.coworking.security.JwtUtil;
@@ -8,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -54,6 +54,7 @@ class RoomControllerTest {
                 )
                 .andExpect(status().isOk());
     }
+
     //FECHA INVALIDA
     @Test
     void getAvailability_fechaInvalida_retorna400() throws Exception {
@@ -82,10 +83,25 @@ class RoomControllerTest {
     @Test
     void getAllRooms_debeRetornar200() throws Exception {
 
-        when(roomService.getAllRooms())
-                .thenReturn(List.of(new RoomDto()));
+        AdminPageResponse<RoomDto> response =
+                AdminPageResponse.<RoomDto>builder()
+                        .content(List.of(new RoomDto()))
+                        .page(0)
+                        .size(10)
+                        .totalElements(1)
+                        .totalPages(1)
+                        .first(true)
+                        .last(true)
+                        .build();
 
-        mockMvc.perform(get("/api/rooms"))
+        when(roomService.getAllRooms(0, 10))
+                .thenReturn(response);
+
+        mockMvc.perform(
+                        get("/api/rooms")
+                                .param("page", "0")
+                                .param("size", "10")
+                )
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/admin/AdminServiceTest.java
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -25,6 +28,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -149,48 +153,56 @@ class AdminServiceTest {
         user.setRoles(Set.of(role));
         user.setCreatedAt(creationTime);
 
-        when(userRepository.findAll())
-                .thenReturn(List.of(user));
+        Page<User> usersPage =
+                new PageImpl<>(List.of(user));
 
-        // Act
-        List<UserAdminResponse> result =
-                adminService.getAllUsers();
+        when(userRepository.findAll(any(Pageable.class)))
+                .thenReturn(usersPage);
+
+        AdminPageResponse<UserAdminResponse> result =
+                adminService.getUsers(0, 10);
 
         // Assert
-        assertEquals(1, result.size());
+        assertEquals(1, result.content().size());
 
         assertEquals(
                 "dayana",
-                result.getFirst().getUsername()
+                result.content().getFirst().getUsername()
         );
 
         assertEquals(
                 "dayana@gmail.com",
-                result.getFirst().getEmail()
+                result.content().getFirst().getEmail()
         );
 
         assertTrue(
-                result.getFirst()
+                result.content()
+                        .getFirst()
                         .getRoles()
                         .contains("ROLE_USER")
         );
 
         assertTrue(
-                result.getFirst()
+                result.content()
+                        .getFirst()
                         .isEnabled()
         );
 
         assertTrue(
-                result.getFirst()
+                result.content()
+                        .getFirst()
                         .isEmailVerified()
         );
 
         assertEquals(
-                creationTime, result.getFirst()
+                creationTime,
+                result.content()
+                        .getFirst()
                         .getCreatedAt()
         );
 
-        verify(userRepository).findAll();
+        verify(userRepository)
+                .findAll(any(Pageable.class));
     }
 
     //create admin
@@ -479,14 +491,19 @@ class AdminServiceTest {
         user.setEmailVerified(true);
         user.setRoles(Set.of(role));
 
-        when(userRepository.findAll())
-                .thenReturn(List.of(user));
+        Page<User> usersPage =
+                new PageImpl<>(List.of(user));
 
-        List<UserAdminResponse> result =
-                adminService.getAllUsers();
+        when(userRepository.findAll(any(Pageable.class)))
+                .thenReturn(usersPage);
+
+        AdminPageResponse<UserAdminResponse> result =
+                adminService.getUsers(0, 10);
 
         assertTrue(
-                result.getFirst().isEmailVerified()
+                result.content()
+                        .getFirst()
+                        .isEmailVerified()
         );
     }
 
@@ -584,7 +601,10 @@ class AdminServiceTest {
         user.setId(1L);
         user.setUsername("dayana");
         user.setEmail("dayana@test.com");
-        user.setRoles(Set.of(userRole));
+        Set<Role> roles = new HashSet<>();
+        roles.add(userRole);
+
+        user.setRoles(roles);
 
         UpdateUserRoleRequest request =
                 new UpdateUserRoleRequest("ROLE_ADMIN");

--- a/src/test/java/com/coworking/resources/service/room/RoomServiceTest.java
+++ b/src/test/java/com/coworking/resources/service/room/RoomServiceTest.java
@@ -1,5 +1,6 @@
 package com.coworking.resources.service.room;
 
+import com.coworking.admin.dto.AdminPageResponse;
 import com.coworking.room.dto.RoomDto;
 import com.coworking.room.model.Room;
 import com.coworking.room.repository.RoomRepository;
@@ -11,6 +12,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
@@ -75,12 +79,25 @@ class RoomServiceTest {
 
     @Test
     void getAllRooms_returnsList() {
-        when(roomRepository.findAll(any(Sort.class))).thenReturn(List.of(room));
 
-        List<RoomDto> rooms = roomService.getAllRooms();
+        Page<Room> roomsPage =
+                new PageImpl<>(List.of(room));
 
-        assertEquals(1, rooms.size());
-        assertEquals("Sala 1", rooms.getFirst().getName());
+        when(roomRepository.findAll(any(Pageable.class)))
+                .thenReturn(roomsPage);
+
+        AdminPageResponse<RoomDto> result =
+                roomService.getAllRooms(0, 10);
+
+        assertEquals(
+                1,
+                result.content().size()
+        );
+
+        assertEquals(
+                "Sala 1",
+                result.content().getFirst().getName()
+        );
     }
 
     @Test
@@ -176,7 +193,7 @@ class RoomServiceTest {
         assertFalse(deleted);
         verify(roomRepository, never()).deleteById(anyLong());
     }
-    
+
     @Test
     void getAllRooms_debeRetornarOrdenAscendentePorCapacidad() {
 
@@ -186,13 +203,24 @@ class RoomServiceTest {
         Room r2 = new Room();
         r2.setCapacity(4);
 
-        when(roomRepository.findAll(any(Sort.class)))
-                .thenReturn(List.of(r2, r1));
+        Page<Room> roomsPage =
+                new PageImpl<>(List.of(r2, r1));
 
-        List<RoomDto> result = roomService.getAllRooms();
+        when(roomRepository.findAll(any(Pageable.class)))
+                .thenReturn(roomsPage);
 
-        assertEquals(4, result.get(0).getCapacity());
-        assertEquals(6, result.get(1).getCapacity());
+        AdminPageResponse<RoomDto> result =
+                roomService.getAllRooms(0, 10);
+
+        assertEquals(
+                4,
+                result.content().get(0).getCapacity()
+        );
+
+        assertEquals(
+                6,
+                result.content().get(1).getCapacity()
+        );
     }
 
     @Test
@@ -245,6 +273,7 @@ class RoomServiceTest {
         verify(storageService).upload(image);
         verify(roomRepository).save(any(Room.class));
     }
+
     //update
     @Test
     void updateRoom_updatesExistingRoom_withoutImage() {


### PR DESCRIPTION
En este PR se implementó soporte de paginación en los módulos administrativos para evitar la carga completa de registros y mejorar la escalabilidad del panel.

## Módulos actualizados
**Reservas**

- Se agregó paginación al endpoint administrativo de reservas.
- Ordenamiento por fecha de creación descendente.

**Pagos**

- Se agregó paginación al endpoint administrativo de pagos.
- Ordenamiento por fecha de pago descendente.

**Usuarios**

- Se agregó paginación al endpoint administrativo de usuarios.
- Ordenamiento por fecha de creación descendente.

**Salas**

- Se agregó paginación al listado de salas.
- Ordenamiento por capacidad ascendente.

## Cambios
**Nuevo DTO reutilizable**

Se creó:

`AdminPageResponse<T>`

para estandarizar las respuestas paginadas de todos los módulos administrativos.

**Servicios**
Se migró el uso de consultas completas `(findAll())` a consultas paginadas utilizando:

```
Pageable
PageRequest
Page<T>
```
**Controladores**
Los endpoints ahora permiten consultar información paginada mediante los parámetros:

```http
?page=0
&size=10
```
**Tests**
Se actualizaron las pruebas unitarias y de controlador para trabajar con respuestas paginadas

---
Closes #124 